### PR TITLE
fix: run ingress installer with sudo in workflow

### DIFF
--- a/.github/workflows/offline-package-nginx-ingress.yaml
+++ b/.github/workflows/offline-package-nginx-ingress.yaml
@@ -150,6 +150,8 @@ jobs:
           mkdir -p $HOME/.kube
           sudo cp /etc/rancher/k3s/k3s.yaml $HOME/.kube/config
           sudo chown $USER:$USER $HOME/.kube/config
+          sudo mkdir -p /root/.kube
+          sudo cp /etc/rancher/k3s/k3s.yaml /root/.kube/config
           kubectl get nodes
           kubectl version --client=true
 
@@ -172,11 +174,10 @@ jobs:
         run: |
           set -euo pipefail
           cd offline-test
-          export KUBECONFIG=$HOME/.kube/config
-          sudo -E bash scripts/ingress-installer.sh
+          sudo bash scripts/ingress-installer.sh
           sleep 10
-          helm list -A
-          kubectl -n ingress get pods
+          sudo helm list -A
+          sudo kubectl -n ingress get pods
 
   publish-release:
     needs: test-offline-installer


### PR DESCRIPTION
## Summary
- run offline nginx ingress installer with sudo and preserved kubeconfig

## Testing
- `yamllint .github/workflows/offline-package-nginx-ingress.yaml` *(fails: command not found)*
- `sudo apt-get update && sudo apt-get install -y yamllint` *(fails: repository 403)*
- `python - <<'PY'\nimport yaml,sys\nyaml.safe_load(open('.github/workflows/offline-package-nginx-ingress.yaml'))\nprint('YAML parse OK')\nPY` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pip install pyyaml >/tmp/pip.log && tail -n 20 /tmp/pip.log` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c698e6c874833284dfa2d843459627