### PR TITLE
fix: sanitize images extraction in APISIX offline workflow

### DIFF
--- a/.github/workflows/offline-package-apisix-gateway.yaml
+++ b/.github/workflows/offline-package-apisix-gateway.yaml
@@ -77,10 +77,11 @@ jobs:
         run: |
           set -euo pipefail
           helm template apisix apisix/apisix --version "${CHART_VERSION}" > manifest.yaml
-          images=$(grep -oP 'image:\s*\K[^\s]+' manifest.yaml | sort -u)
+          images=$(grep -oP 'image:\s*\K[^\s]+' manifest.yaml | tr -d '"' | sort -u)
           for img in $images; do
+            [ -z "$img" ] && continue
             docker pull "$img"
-            safe=$(echo $img | tr '/:' '-_')
+            safe=$(echo "$img" | tr '/:' '-_')
             docker save "$img" -o offline-installer/images/${safe}.tar
           done
 


### PR DESCRIPTION
## Summary
- sanitize image names when extracting from Helm manifest
- skip empty image entries

## Testing
- `yamllint .github/workflows/offline-package-apisix-gateway.yaml` *(fails: command not found)*
- `sudo apt-get update` *(fails: 403 Forbidden)*
- `pip install --user yamllint` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b102b10883328d52faf4ed46545d