### PR TITLE
Align offline Gitea package naming with installer instructions

### DIFF
--- a/.github/workflows/offline-package-gitea-installer.yaml
+++ b/.github/workflows/offline-package-gitea-installer.yaml
@@ -30,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NERDCTL_VERSION: "2.0.3"
+      OFFLINE_DIR: gitea-offline-package
     outputs:
       chart_version: ${{ steps.resolve.outputs.chart_version }}
     steps:
@@ -65,15 +66,15 @@ jobs:
       - name: Prepare directories
         run: |
           set -euo pipefail
-          rm -rf offline-installer
-          mkdir -p offline-installer/{images,charts,scripts,metadata}
+          rm -rf "${OFFLINE_DIR}"
+          mkdir -p "${OFFLINE_DIR}"/{images,charts,scripts,metadata}
 
       - name: Stage installer script
         env:
           CHART_VERSION: ${{ steps.resolve.outputs.chart_version }}
         run: |
           set -euo pipefail
-          cat <<'SCRIPT' > offline-installer/scripts/install-gitea.sh
+          cat <<'SCRIPT' > "${OFFLINE_DIR}/scripts/install-gitea.sh"
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -104,8 +105,8 @@ helm upgrade --install "${RELEASE_NAME}" "${CHART_DIR}" \
   --create-namespace \
   "$@"
 SCRIPT
-          chmod +x offline-installer/scripts/install-gitea.sh
-          cat <<EOFMETA > offline-installer/metadata/INFO
+          chmod +x "${OFFLINE_DIR}/scripts/install-gitea.sh"
+          cat <<EOFMETA > "${OFFLINE_DIR}/metadata/INFO"
 chart: gitea-charts/gitea
 chart_version: ${CHART_VERSION}
 created_at: $(date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -115,7 +116,7 @@ EOFMETA
         run: |
           set -euo pipefail
           wget https://github.com/containerd/nerdctl/releases/download/v${NERDCTL_VERSION}/nerdctl-${NERDCTL_VERSION}-linux-${{ matrix.arch }}.tar.gz \
-            -O offline-installer/nerdctl.tar.gz
+            -O "${OFFLINE_DIR}/nerdctl.tar.gz"
 
       - name: Pull & export required images
         env:
@@ -137,7 +138,7 @@ EOFMETA
               continue
             fi
             safe=$(echo "$img" | tr '/:' '-_')
-            docker save "$img" -o "offline-installer/images/${safe}.tar"
+            docker save "$img" -o "${OFFLINE_DIR}/images/${safe}.tar"
           done
 
       - name: Download Helm chart
@@ -145,19 +146,19 @@ EOFMETA
           CHART_VERSION: ${{ steps.resolve.outputs.chart_version }}
         run: |
           set -euo pipefail
-          helm pull gitea-charts/gitea --version "${CHART_VERSION}" --untar --untardir offline-installer/charts
+          helm pull gitea-charts/gitea --version "${CHART_VERSION}" --untar --untardir "${OFFLINE_DIR}/charts"
 
       - name: Package offline installer
         run: |
           set -euo pipefail
-          tar -czf offline-setup-gitea-${{ matrix.arch }}.tar.gz -C offline-installer .
-          ls -lh offline-setup-gitea-${{ matrix.arch }}.tar.gz
+          tar -czf offline-package-gitea-${{ matrix.arch }}.tar.gz "${OFFLINE_DIR}"
+          ls -lh offline-package-gitea-${{ matrix.arch }}.tar.gz
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: offline-setup-gitea-${{ matrix.arch }}
-          path: offline-setup-gitea-${{ matrix.arch }}.tar.gz
+          name: offline-package-gitea-${{ matrix.arch }}
+          path: offline-package-gitea-${{ matrix.arch }}.tar.gz
 
   test-offline-installer:
     needs: build-offline-installer
@@ -169,14 +170,14 @@ EOFMETA
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: offline-setup-gitea-${{ matrix.arch }}
+          name: offline-package-gitea-${{ matrix.arch }}
           path: offline-test
 
       - name: Verify offline package integrity
         run: |
           set -euo pipefail
           cd offline-test
-          tar -tzf offline-setup-gitea-${{ matrix.arch }}.tar.gz > /dev/null
+          tar -tzf offline-package-gitea-${{ matrix.arch }}.tar.gz > /dev/null
 
   publish-release:
     needs: test-offline-installer
@@ -204,13 +205,13 @@ EOFMETA
       - name: Download amd64 artifact
         uses: actions/download-artifact@v4
         with:
-          name: offline-setup-gitea-amd64
+          name: offline-package-gitea-amd64
           path: release-artifacts/amd64
 
       - name: Download arm64 artifact
         uses: actions/download-artifact@v4
         with:
-          name: offline-setup-gitea-arm64
+          name: offline-package-gitea-arm64
           path: release-artifacts/arm64
 
       - name: Upload offline installers to GitHub Release
@@ -218,8 +219,8 @@ EOFMETA
         with:
           tag_name: ${{ env.TAG_NAME }}
           files: |
-            release-artifacts/amd64/offline-setup-gitea-amd64.tar.gz
-            release-artifacts/arm64/offline-setup-gitea-arm64.tar.gz
+            release-artifacts/amd64/offline-package-gitea-amd64.tar.gz
+            release-artifacts/arm64/offline-package-gitea-arm64.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -244,8 +245,8 @@ EOFMETA
           ssh -i ~/.ssh/id_rsa "${RSYNC_SSH_USER}@${VPS_HOST}" "mkdir -p '${REMOTE_DIR}'"
           echo "Rsync -> ${VPS_HOST}:${REMOTE_DIR}/"
           rsync -av -e "ssh -i ~/.ssh/id_rsa" \
-            release-artifacts/amd64/offline-setup-gitea-amd64.tar.gz \
-            release-artifacts/arm64/offline-setup-gitea-arm64.tar.gz \
+            release-artifacts/amd64/offline-package-gitea-amd64.tar.gz \
+            release-artifacts/arm64/offline-package-gitea-arm64.tar.gz \
             "${RSYNC_SSH_USER}@${VPS_HOST}:${REMOTE_DIR}/"
 
   retention:


### PR DESCRIPTION
## Summary
- package the offline installer into a gitea-offline-package directory and archive named offline-package-gitea-<arch>.tar.gz
- update downstream workflow steps to use the new artifact names when testing, releasing, and syncing installers

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68de6c784a708332a09eede0aba7397e