### PR TITLE
Align offline Gitea installer layout with usage instructions

### DIFF
--- a/.github/workflows/offline-package-gitea-installer.yaml
+++ b/.github/workflows/offline-package-gitea-installer.yaml
@@ -67,18 +67,18 @@ jobs:
         run: |
           set -euo pipefail
           rm -rf "${OFFLINE_DIR}"
-          mkdir -p "${OFFLINE_DIR}"/{images,charts,scripts,metadata}
+          mkdir -p "${OFFLINE_DIR}"/{images,charts,metadata}
 
       - name: Stage installer script
         env:
           CHART_VERSION: ${{ steps.resolve.outputs.chart_version }}
         run: |
           set -euo pipefail
-          cat <<'SCRIPT' > "${OFFLINE_DIR}/scripts/install-gitea.sh"
+          cat <<'SCRIPT' > "${OFFLINE_DIR}/install-gitea.sh"
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CHART_DIR="${ROOT_DIR}/charts/gitea"
 IMAGES_DIR="${ROOT_DIR}/images"
 RELEASE_NAME="${RELEASE_NAME:-gitea}"
@@ -105,7 +105,7 @@ helm upgrade --install "${RELEASE_NAME}" "${CHART_DIR}" \
   --create-namespace \
   "$@"
 SCRIPT
-          chmod +x "${OFFLINE_DIR}/scripts/install-gitea.sh"
+          chmod +x "${OFFLINE_DIR}/install-gitea.sh"
           cat <<EOFMETA > "${OFFLINE_DIR}/metadata/INFO"
 chart: gitea-charts/gitea
 chart_version: ${CHART_VERSION}
@@ -178,6 +178,13 @@ EOFMETA
           set -euo pipefail
           cd offline-test
           tar -tzf offline-package-gitea-${{ matrix.arch }}.tar.gz > /dev/null
+
+      - name: Verify install script layout
+        run: |
+          set -euo pipefail
+          cd offline-test
+          tar -xvpf offline-package-gitea-${{ matrix.arch }}.tar.gz
+          test -f gitea-offline-package/install-gitea.sh
 
   publish-release:
     needs: test-offline-installer


### PR DESCRIPTION
## Summary
- place the generated install-gitea.sh script at the package root so the documented command works
- add a CI check that extracts the offline package and asserts the expected script path exists

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de6e7cbbd48332990a7591638f6d93