### PR TITLE
Refactor workflow scripts

### DIFF
--- a/.github/workflows/offline-package-pulumi-installer.yaml
+++ b/.github/workflows/offline-package-pulumi-installer.yaml
@@ -43,73 +43,13 @@ jobs:
         id: resolve
         env:
           OVERRIDE_VERSION: ${{ github.event.inputs.pulumi_version }}
-        run: |
-          set -euo pipefail
-          if [ -n "${OVERRIDE_VERSION}" ]; then
-            VERSION="${OVERRIDE_VERSION}"
-          else
-            VERSION=$(curl -fsSL https://api.github.com/repos/pulumi/pulumi/releases?per_page=100 \
-              | jq -r '.[].tag_name' \
-              | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
-              | sed 's/^v//' \
-              | sort -V \
-              | tail -n 1)
-          fi
-          if [ -z "${VERSION}" ]; then
-            echo "Failed to resolve Pulumi version" >&2
-            exit 1
-          fi
-          echo "Resolved Pulumi version: ${VERSION}"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+        run: script/resolve-pulumi-version.sh
 
       - name: Build offline Pulumi package
         env:
+          ARCH: ${{ matrix.arch }}
           PULUMI_VERSION: ${{ steps.resolve.outputs.version }}
-        run: |
-          set -euo pipefail
-          ARCH="${{ matrix.arch }}"
-          case "$ARCH" in
-            amd64) ASSET_ARCH="x64" ;;
-            arm64) ASSET_ARCH="arm64" ;;
-            *) echo "Unsupported arch: $ARCH" >&2; exit 1 ;;
-          esac
-          WORKDIR="pulumi-offline-package"
-          rm -rf "${WORKDIR}"
-          mkdir -p "${WORKDIR}" "${WORKDIR}/scripts"
-
-          ARCHIVE="pulumi-v${PULUMI_VERSION}-linux-${ASSET_ARCH}.tar.gz"
-          URL="https://get.pulumi.com/releases/sdk/${ARCHIVE}"
-          echo "Downloading ${URL}"
-          curl -fSL "${URL}" -o "${ARCHIVE}"
-
-          tar -xzvf "${ARCHIVE}" -C "${WORKDIR}" --strip-components=1
-          rm -f "${ARCHIVE}"
-
-          echo "${PULUMI_VERSION}" > "${WORKDIR}/VERSION"
-
-          cat <<'SCRIPT' > "${WORKDIR}/scripts/install-pulumi.sh"
-#!/usr/bin/env bash
-set -euo pipefail
-
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-BIN_DIR="${ROOT_DIR}/bin"
-INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
-
-if [[ "${1:-}" == "--install" ]]; then
-  sudo install -m 0755 "${BIN_DIR}"/* "${INSTALL_DIR}/"
-  echo "Pulumi binaries installed to ${INSTALL_DIR}"
-else
-  cat <<USAGE
-Usage: $(basename "$0") --install
-  --install    Copy Pulumi CLI binaries into ${INSTALL_DIR}
-USAGE
-fi
-SCRIPT
-          chmod +x "${WORKDIR}/scripts/install-pulumi.sh"
-
-          OUTPUT_ARCHIVE="offline-package-pulumi-${ARCH}.tar.gz"
-          tar -czf "${OUTPUT_ARCHIVE}" "${WORKDIR}"
-          ls -lh "${OUTPUT_ARCHIVE}"
+        run: script/build-offline-pulumi-package.sh
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -139,17 +79,9 @@ SCRIPT
 
       - name: Verify Pulumi bundle
         env:
+          ARCH: ${{ matrix.arch }}
           PULUMI_VERSION: ${{ needs.build-offline-installer.outputs.version }}
-        run: |
-          set -euo pipefail
-          cd test-dir/pulumi-offline-package
-          test -f VERSION
-          if [ "${{ matrix.arch }}" = "amd64" ]; then
-            ./bin/pulumi version
-            ./bin/pulumi version | grep "v${PULUMI_VERSION}"
-          else
-            file ./bin/pulumi | grep -E "ARM|aarch64"
-          fi
+        run: script/verify-pulumi-bundle.sh
 
   publish-release:
     needs: test-offline-installer
@@ -211,15 +143,7 @@ SCRIPT
           ssh-keyscan -H "$VPS_HOST" >> ~/.ssh/known_hosts
 
       - name: Rsync release assets to remote
-        run: |
-          set -euo pipefail
-          REMOTE_DIR="${REMOTE_ROOT}/${TAG_NAME}"
-          ssh -i ~/.ssh/id_rsa "${RSYNC_SSH_USER}@${VPS_HOST}" "mkdir -p '${REMOTE_DIR}'"
-          echo "Rsync -> ${VPS_HOST}:${REMOTE_DIR}/"
-          rsync -av -e "ssh -i ~/.ssh/id_rsa" \
-            release-artifacts/amd64/offline-package-pulumi-amd64.tar.gz \
-            release-artifacts/arm64/offline-package-pulumi-arm64.tar.gz \
-            "${RSYNC_SSH_USER}@${VPS_HOST}:${REMOTE_DIR}/"
+        run: script/rsync-release-assets.sh
 
   retention:
     name: Remote retention (keep latest 3)
@@ -240,20 +164,4 @@ SCRIPT
           ssh-keyscan -H "$VPS_HOST" >> ~/.ssh/known_hosts
 
       - name: Prune old versions on remote (keep 3)
-        run: |
-          set -euo pipefail
-          ssh -i ~/.ssh/id_rsa "${RSYNC_SSH_USER}@${VPS_HOST}" bash -lc '
-            set -euo pipefail
-            cd "'"${REMOTE_ROOT}"'" || exit 0
-            keep=3
-            mapfile -t all < <(ls -1 | grep -E "^(offline-pulumi-|v[0-9]+\.)" | sort -V -r || true)
-            if [ "${#all[@]}" -le "$keep" ]; then
-              echo "Nothing to prune. Count=${#all[@]}"
-              exit 0
-            fi
-            to_delete=("${all[@]:keep}")
-            echo "Pruning old versions: ${to_delete[*]}"
-            for d in "${to_delete[@]}"; do
-              rm -rf -- "$d"
-            done
-          '
+        run: script/prune-remote-versions.sh

--- a/script/build-offline-pulumi-package.sh
+++ b/script/build-offline-pulumi-package.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PULUMI_VERSION="${PULUMI_VERSION:?PULUMI_VERSION is required}"
+ARCH="${ARCH:-}"
+
+if [ -z "${ARCH}" ]; then
+  echo "ARCH environment variable is required" >&2
+  exit 1
+fi
+
+case "${ARCH}" in
+  amd64) ASSET_ARCH="x64" ;;
+  arm64) ASSET_ARCH="arm64" ;;
+  *)
+    echo "Unsupported arch: ${ARCH}" >&2
+    exit 1
+    ;;
+esac
+
+WORKDIR="pulumi-offline-package"
+rm -rf "${WORKDIR}"
+mkdir -p "${WORKDIR}" "${WORKDIR}/scripts"
+
+ARCHIVE="pulumi-v${PULUMI_VERSION}-linux-${ASSET_ARCH}.tar.gz"
+URL="https://get.pulumi.com/releases/sdk/${ARCHIVE}"
+echo "Downloading ${URL}"
+curl -fSL "${URL}" -o "${ARCHIVE}"
+
+tar -xzvf "${ARCHIVE}" -C "${WORKDIR}" --strip-components=1
+rm -f "${ARCHIVE}"
+
+echo "${PULUMI_VERSION}" > "${WORKDIR}/VERSION"
+
+cat <<'SCRIPT' > "${WORKDIR}/scripts/install-pulumi.sh"
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN_DIR="${ROOT_DIR}/bin"
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+
+if [[ "${1:-}" == "--install" ]]; then
+  sudo install -m 0755 "${BIN_DIR}"/* "${INSTALL_DIR}/"
+  echo "Pulumi binaries installed to ${INSTALL_DIR}"
+else
+  cat <<USAGE
+Usage: $(basename "$0") --install
+  --install    Copy Pulumi CLI binaries into ${INSTALL_DIR}
+USAGE
+fi
+SCRIPT
+chmod +x "${WORKDIR}/scripts/install-pulumi.sh"
+
+OUTPUT_ARCHIVE="offline-package-pulumi-${ARCH}.tar.gz"
+tar -czf "${OUTPUT_ARCHIVE}" "${WORKDIR}"
+ls -lh "${OUTPUT_ARCHIVE}"

--- a/script/prune-remote-versions.sh
+++ b/script/prune-remote-versions.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REMOTE_ROOT="${REMOTE_ROOT:?REMOTE_ROOT is required}"
+RSYNC_SSH_USER="${RSYNC_SSH_USER:?RSYNC_SSH_USER is required}"
+VPS_HOST="${VPS_HOST:?VPS_HOST is required}"
+
+ssh -i ~/.ssh/id_rsa "${RSYNC_SSH_USER}@${VPS_HOST}" bash -lc '
+  set -euo pipefail
+  cd "'"${REMOTE_ROOT}"'" || exit 0
+  keep=3
+  mapfile -t all < <(ls -1 | grep -E "^(offline-pulumi-|v[0-9]+\.)" | sort -V -r || true)
+  if [ "${#all[@]}" -le "$keep" ]; then
+    echo "Nothing to prune. Count=${#all[@]}"
+    exit 0
+  fi
+  to_delete=("${all[@]:keep}")
+  echo "Pruning old versions: ${to_delete[*]}"
+  for d in "${to_delete[@]}"; do
+    rm -rf -- "$d"
+  done
+'

--- a/script/resolve-pulumi-version.sh
+++ b/script/resolve-pulumi-version.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OVERRIDE_VERSION="${OVERRIDE_VERSION:-}"
+
+if [ -n "${OVERRIDE_VERSION}" ]; then
+  VERSION="${OVERRIDE_VERSION}"
+else
+  VERSION=$(curl -fsSL https://api.github.com/repos/pulumi/pulumi/releases?per_page=100 \
+    | jq -r '.[].tag_name' \
+    | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+    | sed 's/^v//' \
+    | sort -V \
+    | tail -n 1)
+fi
+
+if [ -z "${VERSION}" ]; then
+  echo "Failed to resolve Pulumi version" >&2
+  exit 1
+fi
+
+echo "Resolved Pulumi version: ${VERSION}"
+echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"

--- a/script/rsync-release-assets.sh
+++ b/script/rsync-release-assets.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REMOTE_ROOT="${REMOTE_ROOT:?REMOTE_ROOT is required}"
+TAG_NAME="${TAG_NAME:?TAG_NAME is required}"
+RSYNC_SSH_USER="${RSYNC_SSH_USER:?RSYNC_SSH_USER is required}"
+VPS_HOST="${VPS_HOST:?VPS_HOST is required}"
+
+REMOTE_DIR="${REMOTE_ROOT}/${TAG_NAME}"
+ssh -i ~/.ssh/id_rsa "${RSYNC_SSH_USER}@${VPS_HOST}" "mkdir -p '${REMOTE_DIR}'"
+echo "Rsync -> ${VPS_HOST}:${REMOTE_DIR}/"
+rsync -av -e "ssh -i ~/.ssh/id_rsa" \
+  release-artifacts/amd64/offline-package-pulumi-amd64.tar.gz \
+  release-artifacts/arm64/offline-package-pulumi-arm64.tar.gz \
+  "${RSYNC_SSH_USER}@${VPS_HOST}:${REMOTE_DIR}/"

--- a/script/verify-pulumi-bundle.sh
+++ b/script/verify-pulumi-bundle.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARCH="${ARCH:-}"
+PULUMI_VERSION="${PULUMI_VERSION:-}"
+
+if [ -z "${ARCH}" ]; then
+  echo "ARCH environment variable is required" >&2
+  exit 1
+fi
+
+cd test-dir/pulumi-offline-package
+
+test -f VERSION
+
+if [ "${ARCH}" = "amd64" ]; then
+  ./bin/pulumi version
+  ./bin/pulumi version | grep "v${PULUMI_VERSION}"
+else
+  file ./bin/pulumi | grep -E "ARM|aarch64"
+fi


### PR DESCRIPTION
## Summary
- replace the long inline `run` blocks in the offline Pulumi workflow with calls to dedicated scripts
- add scripts for resolving the Pulumi version, building the offline package, verifying the bundle, syncing release assets, and pruning remote versions

## Testing
- not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68de73212d4883329f389ad9d6cacf29