### PR TITLE
Fix packer validate path for golden image workflow

### DIFF
--- a/.github/workflows/cloud-neutra-golden-image.yaml
+++ b/.github/workflows/cloud-neutra-golden-image.yaml
@@ -26,7 +26,7 @@ env:
   BASE_REGION: ap-northeast-1
   TARGET_REGIONS: "ap-northeast-1 ap-east-1 us-west-1"
   PROJECT_TAG: Cloud-Neutra
-  PACKER_TEMPLATE_ROOT: packer/Cloud-Neutra-VMs
+  PACKER_TEMPLATE_ROOT: packer/Cloud-Neutra-VMs/templates
 
 jobs:
   ##########################################################################
@@ -56,7 +56,7 @@ jobs:
         run: packer fmt -recursive .
 
       - name: Packer Validate
-        run: packer validate .
+        run: packer validate "${PACKER_TEMPLATE_ROOT}"
 
       - name: gitleaks Scan
         uses: gitleaks/gitleaks-action@v2


### PR DESCRIPTION
## Summary
- point PACKER_TEMPLATE_ROOT to the templates directory
- run packer validate against the template root to avoid missing config errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920223da8c4833282d8d056272c3b41)