### PR TITLE
feat(oci): caddy image with cloudflare dns provider

### DIFF
--- a/.github/workflows/build-ci-image-caddy.yml
+++ b/.github/workflows/build-ci-image-caddy.yml
@@ -1,0 +1,63 @@
+name: build image caddy
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'oci/base/caddy/Dockerfile'
+      - '.github/workflows/build-ci-image-caddy.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'oci/base/caddy/Dockerfile'
+      - '.github/workflows/build-ci-image-caddy.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/caddy-cloudflare
+
+jobs:
+  caddy:
+    name: Build caddy image with cloudflare dns
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image
+        run: |
+          short_sha="$(git rev-parse --short HEAD)"
+          echo "SHORT_SHA=${short_sha}" >> "$GITHUB_ENV"
+          docker build \
+            -t "${IMAGE_NAME}:${short_sha}" \
+            -t "${IMAGE_NAME}:latest" \
+            oci/base/caddy
+
+      # Dockerfile 里已有一次 list-modules 自检, 但那是构建期的。这里再验一次
+      # 运行期的镜像: 构建缓存命中或多阶段拷贝出错时, 构建期通过而运行期缺模块
+      # 是可能的, 而这个模块缺失只有在真正签证书时才暴露。
+      - name: Verify cloudflare dns provider is present in the built image
+        run: |
+          set -euo pipefail
+          docker run --rm "${IMAGE_NAME}:${SHORT_SHA}" caddy list-modules \
+            | grep -q '^dns\.providers\.cloudflare$'
+          echo "dns.providers.cloudflare present"
+
+      # PR 只构建验证, 推送仅发生在 main push / 手动触发
+      - name: Push image
+        if: github.event_name != 'pull_request'
+        run: |
+          docker push "${IMAGE_NAME}:${SHORT_SHA}"
+          docker push "${IMAGE_NAME}:latest"

--- a/oci/base/caddy/Dockerfile
+++ b/oci/base/caddy/Dockerfile
@@ -1,0 +1,35 @@
+# Caddy + Cloudflare DNS provider.
+#
+# 官方 caddy:2-alpine 不含任何 DNS provider 模块, 因此只能做 HTTP-01 挑战 ——
+# 那要求域名的 A 记录已经指向本机。web-saas 的交付顺序是"先部署新主机、最后
+# 才切 DNS", 在切换之前 HTTP-01 必然签不出证书。DNS-01 不需要 A 记录指过来,
+# 而且是签发泛域名证书(*.onwalk.net)的唯一途径。
+#
+# 自建而不是直接引用社区镜像(caddybuilds/caddy-cloudflare 等): Caddy 是直接
+# 终结 TLS、持有全站私钥的组件, 它的供应链必须自己控制。这里只从上游官方
+# caddy 镜像取 builder 与 runtime, 中间的编译过程在我们自己的流水线里发生。
+#
+# 版本钉死到具体小版本而不是 :2 —— 浮动 tag 会让"同一个 Dockerfile 构建出
+# 行为不同的镜像", 排查 TLS 问题时这是最难受的一类不确定性。
+ARG CADDY_VERSION=2.10.0
+
+FROM caddy:${CADDY_VERSION}-builder-alpine AS builder
+
+# xcaddy 会拉取模块源码重新编译 caddy 二进制。模块版本同样钉死。
+ARG CLOUDFLARE_MODULE_VERSION=v0.2.4
+RUN xcaddy build \
+      --with github.com/caddy-dns/cloudflare@${CLOUDFLARE_MODULE_VERSION}
+
+FROM caddy:${CADDY_VERSION}-alpine
+
+LABEL org.opencontainers.image.title="caddy with cloudflare dns" \
+      org.opencontainers.image.description="Caddy built with the caddy-dns/cloudflare provider for ACME DNS-01 and wildcard certificates" \
+      org.opencontainers.image.source="https://github.com/ai-workspace-infra/artifacts"
+
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy
+
+# 构建期自检: 模块没被编译进去时, 镜像照样能跑, 只有在真正签证书的时候才
+# 报 "unknown module dns.providers.cloudflare" —— 那已经是生产环境半夜的事了。
+# 这一行让缺模块在构建期就失败。
+RUN caddy list-modules | grep -q '^dns\.providers\.cloudflare$' \
+    || (echo "cloudflare dns provider missing from build" >&2; exit 1)


### PR DESCRIPTION
第一步,为 web-saas 切到 ACME DNS-01 + 泛域名证书做准备。

## 为什么需要自己的 caddy 镜像

官方 `caddy:2-alpine` **不含任何 DNS provider 模块**,只能做 HTTP-01 挑战 —— 那要求域名 A 记录已经指向本机。而 web-saas 的交付顺序是「先部署新主机、最后才切 DNS」,在切换之前 HTTP-01 必然签不出证书。这正是 2026-07-28 `console-uat` 一直没有证书的结构性原因之一。

DNS-01 不需要 A 记录指过来,也是签发泛域名证书(`*.onwalk.net`)的唯一途径。

## 为什么自建而不是用社区镜像

`caddybuilds/caddy-cloudflare` 这类现成镜像改动更小,但 caddy 是**直接终结 TLS、持有全站私钥**的组件,供应链必须自己控制。这里只从上游官方 caddy 镜像取 builder 与 runtime,编译过程发生在我们自己的流水线里。

## 实现要点

- 版本**钉到具体小版本**(`caddy 2.10.0` / `caddy-dns/cloudflare v0.2.4`),不用浮动 `:2`。浮动 tag 会让同一个 Dockerfile 构建出行为不同的镜像,排查 TLS 问题时这是最难受的一类不确定性。两个上游 tag 已确认存在。
- **模块缺失做了两道自检**。这一点值得特别说明:模块没编进去时镜像照样能正常启动,只有在真正签证书那一刻才报 `unknown module dns.providers.cloudflare` —— 那已经是生产环境半夜的事了。所以构建期在 Dockerfile 里 `list-modules` 验一次;流水线里再对**构建出的镜像** `docker run` 验一次,因为构建缓存命中或多阶段拷贝出错时,构建期通过而运行期缺模块是可能的。
- 流水线沿用本仓既有约定(对齐 `build-ci-image-stunnel-client.yml`):PR 只构建验证,推送只发生在 main push / 手动触发;`paths` 只盯 Dockerfile 与本 workflow。

产出 `ghcr.io/ai-workspace-infra/caddy-cloudflare:{latest,<short-sha>}`。

## 验证状态

YAML 解析通过;两个上游 tag 均已确认存在。**未在本地实际构建** —— 本机没有 docker daemon,依赖 CI 首次构建验证。镜像里的两道自检就是为这种「没能本地验」的情况准备的:真缺模块的话 CI 会直接红,不会把一个坏镜像推上去。

## 后续

本 PR 只造镜像,不改任何运行中的东西。接线在后续 PR:
- playbooks:Caddyfile 改泛域名 + DNS-01;web-saas secrets 注入 `CLOUDFLARE_DNS_API_TOKEN`
- gitops:`CADDY_IMAGE` 指向新镜像,并给 caddy 服务补 `env_file`(现在它没有,拿不到 token)
- platform-ops-toolkit:从 Vault `kv/CICD` 取 token 下发;证书持久化到 Vault,重建后恢复以实现无限次重建

🤖 Generated with [Claude Code](https://claude.com/claude-code)