### PR TITLE
fix(ci): move ansible-lint off the dead images.onwalk.net registry

### DIFF
--- a/.github/workflows/ansible-lint-container.yml
+++ b/.github/workflows/ansible-lint-container.yml
@@ -14,8 +14,16 @@ jobs:
   ansible-lint:
     runs-on: ubuntu-latest
 
+    # 原本指向 images.onwalk.net —— 那个私有 registry 已经解析不了
+    # (dial tcp: lookup images.onwalk.net: no such host), 于是本仓**每一个**
+    # PR 的 lint 都红, 红到没人再看它。改用组织自己的 GHCR, 镜像由同仓
+    # build-ci-image-alpine-ansible-lint.yml 从 oci/base/alpine-ansible-lint/
+    # 构建, 与 stunnel / caddy 等其余基础镜像同一套约定。
     container:
-      image: images.onwalk.net/public/base/alpine-ansible-ci-runner:0c09618
+      image: ghcr.io/ai-workspace-infra/alpine-ansible-lint:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/build-ci-image-alpine-ansible-lint.yml
+++ b/.github/workflows/build-ci-image-alpine-ansible-lint.yml
@@ -1,0 +1,58 @@
+name: build image alpine-ansible-lint
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'oci/base/alpine-ansible-lint/**'
+      - '.github/workflows/build-ci-image-alpine-ansible-lint.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'oci/base/alpine-ansible-lint/**'
+      - '.github/workflows/build-ci-image-alpine-ansible-lint.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/alpine-ansible-lint
+
+jobs:
+  alpine-ansible-lint:
+    name: Build alpine-ansible-lint image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image
+        run: |
+          short_sha="$(git rev-parse --short HEAD)"
+          echo "SHORT_SHA=${short_sha}" >> "$GITHUB_ENV"
+          docker build \
+            -t "${IMAGE_NAME}:${short_sha}" \
+            -t "${IMAGE_NAME}:latest" \
+            oci/base/alpine-ansible-lint
+
+      - name: Verify ansible-lint runs in the built image
+        run: |
+          set -euo pipefail
+          docker run --rm "${IMAGE_NAME}:${SHORT_SHA}" ansible-lint --version
+
+      # PR 只构建验证, 推送仅发生在 main push / 手动触发
+      - name: Push image
+        if: github.event_name != 'pull_request'
+        run: |
+          docker push "${IMAGE_NAME}:${SHORT_SHA}"
+          docker push "${IMAGE_NAME}:latest"


### PR DESCRIPTION
## 问题

`ansible-lint` 的 container 指向 `images.onwalk.net`,而那个私有 registry 已经解析不了:

```
Error response from daemon: Get "https://images.onwalk.net/v2/":
dial tcp: lookup images.onwalk.net on 127.0.0.53:53: no such host
```

结果是本仓**每一个 PR** 的 lint 都红,包括刚合并的 #183。一个恒红的检查等于没有检查 —— 真出问题时没人会注意到它变红了。

## 改法

改用组织自己的 GHCR。镜像从仓内已有的 `oci/base/alpine-ansible-lint/`(Dockerfile 一直在,只是没有构建流水线)构建,沿用 stunnel / caddy 那套约定:PR 只构建验证、push main 才推送,并加一条 `ansible-lint --version` 运行期自检。

产出 `ghcr.io/ai-workspace-infra/alpine-ansible-lint:{latest,<short-sha>}`。

## 一次性引导(需要知情)

镜像要等**本 PR 合入 main 后**才会被构建出来,所以本 PR 自己的 lint 检查仍会失败。这不是回归 —— 它今天本来就在失败。合入后即恢复正常。

## 不在本 PR 范围

组织内 `images.onwalk.net` 还有约 180 处引用(`sync-images-*.yaml`、`build-python-3.10-base-images.yml` 等)。那些是镜像同步任务,不阻塞 PR,属于独立的迁移工作。

🤖 Generated with [Claude Code](https://claude.com/claude-code)