### PR TITLE
fix(charts): publish OCI packages to org GHCR

### DIFF
--- a/.github/workflows/release-oci-charts.yml
+++ b/.github/workflows/release-oci-charts.yml
@@ -15,6 +15,9 @@ permissions:
   contents: read
   packages: write
 
+env:
+  GHCR_NAMESPACE: ghcr.io/${{ github.repository_owner }}
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -63,5 +66,5 @@ jobs:
         run: |
           set -euo pipefail
           for pkg in dist/*.tgz; do
-            helm push "${pkg}" oci://ghcr.io/x-evor
+            helm push "${pkg}" "oci://${GHCR_NAMESPACE}"
           done

--- a/docs/tasks/2026-07-29-public-ghcr-org-packages.md
+++ b/docs/tasks/2026-07-29-public-ghcr-org-packages.md
@@ -1,0 +1,17 @@
+# Public GHCR organization packages
+
+## Finding
+
+The `stunnel-server`, `stunnel-client`, and `charts/postgresql` packages under
+`ai-workspace-infra` were private even though the source repositories are public.
+`caddy-cloudflare` was already public.
+
+## Fix
+
+The OCI chart release workflow previously pushed to the unrelated `x-evor`
+namespace. It now derives the namespace from `github.repository_owner`, so runs
+from this repository publish to `ghcr.io/ai-workspace-infra`.
+
+Package visibility remains a package-level GitHub setting and must be changed in
+each package's Settings page. This is intentionally separate from repository
+visibility.


### PR DESCRIPTION
修复 OCI chart 发布目标并记录 GHCR 包可见性问题。

- 将错误的 ghcr.io/x-evor 改为 ghcr.io/${{ github.repository_owner }}
- ai-workspace-infra 下的 stunnel-server、stunnel-client、charts/postgresql 仍需在包 Settings 中改为 Public
- caddy-cloudflare 已是 Public

验证：git diff --check