### PR TITLE
feat(packer): add production runtime Golden Image templates for Web SaaS and Agent Proxy

### DIFF
--- a/packer/debian13-docker-compose-websaas.pkr.hcl
+++ b/packer/debian13-docker-compose-websaas.pkr.hcl
@@ -1,0 +1,66 @@
+packer {
+  required_plugins {
+    qemu = {
+      version = "~> 1.0"
+      source  = "github.com/hashicorp/qemu"
+    }
+  }
+}
+
+variable "iso_url" {
+  type    = string
+  default = "https://cdimage.debian.org/cdimage/daily-builds/daily/arch-latest/amd64/iso-cd/debian-testing-amd64-netinst.iso"
+}
+
+variable "iso_checksum" {
+  type    = string
+  default = "none"
+}
+
+source "qemu" "debian13_docker_compose_websaas" {
+  iso_url          = var.iso_url
+  iso_checksum     = var.iso_checksum
+  output_directory = "output-debian13-docker-compose-websaas"
+  shutdown_command = "echo 'packer' | sudo -S shutdown -P now"
+  disk_size        = "20G"
+  format           = "qcow2"
+  accelerator      = "kvm"
+  ssh_username     = "packer"
+  ssh_password     = "packer"
+  ssh_timeout      = "20m"
+  vm_name          = "debian13-docker-compose-websaas-golden.qcow2"
+  net_device       = "virtio-net"
+  disk_interface   = "virtio"
+  boot_wait        = "10s"
+  boot_command = [
+    "<esc><wait>",
+    "install <wait>",
+    " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg <wait>",
+    "debian-installer=en_US.UTF-8 <wait>",
+    "auto <wait>",
+    "locale=en_US.UTF-8 <wait>",
+    "kbd-chooser/method=us <wait>",
+    "keyboard-configuration/xkb-keymap=us <wait>",
+    "netcfg/get_hostname=debian13-websaas <wait>",
+    "netcfg/get_domain=local <wait>",
+    "fb=false <wait>",
+    "debconf/frontend=noninteractive <wait>",
+    "console-setup/ask_detect=false <wait>",
+    "console-keymaps-at/keymap=us <wait>",
+    "grub-installer/bootdev=/dev/vda <wait>",
+    "<enter><wait>"
+  ]
+  http_directory = "http"
+}
+
+build {
+  sources = ["source.qemu.debian13_docker_compose_websaas"]
+
+  provisioner "shell" {
+    script = "scripts/setup-websaas-runtime.sh"
+  }
+
+  provisioner "shell" {
+    script = "scripts/cleanup-golden-image.sh"
+  }
+}

--- a/packer/debian13-systemd-agent-proxy.pkr.hcl
+++ b/packer/debian13-systemd-agent-proxy.pkr.hcl
@@ -1,0 +1,66 @@
+packer {
+  required_plugins {
+    qemu = {
+      version = "~> 1.0"
+      source  = "github.com/hashicorp/qemu"
+    }
+  }
+}
+
+variable "iso_url" {
+  type    = string
+  default = "https://cdimage.debian.org/cdimage/daily-builds/daily/arch-latest/amd64/iso-cd/debian-testing-amd64-netinst.iso"
+}
+
+variable "iso_checksum" {
+  type    = string
+  default = "none"
+}
+
+source "qemu" "debian13_systemd_agent_proxy" {
+  iso_url          = var.iso_url
+  iso_checksum     = var.iso_checksum
+  output_directory = "output-debian13-systemd-agent-proxy"
+  shutdown_command = "echo 'packer' | sudo -S shutdown -P now"
+  disk_size        = "20G"
+  format           = "qcow2"
+  accelerator      = "kvm"
+  ssh_username     = "packer"
+  ssh_password     = "packer"
+  ssh_timeout      = "20m"
+  vm_name          = "debian13-systemd-agent-proxy-golden.qcow2"
+  net_device       = "virtio-net"
+  disk_interface   = "virtio"
+  boot_wait        = "10s"
+  boot_command = [
+    "<esc><wait>",
+    "install <wait>",
+    " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg <wait>",
+    "debian-installer=en_US.UTF-8 <wait>",
+    "auto <wait>",
+    "locale=en_US.UTF-8 <wait>",
+    "kbd-chooser/method=us <wait>",
+    "keyboard-configuration/xkb-keymap=us <wait>",
+    "netcfg/get_hostname=debian13-agent-proxy <wait>",
+    "netcfg/get_domain=local <wait>",
+    "fb=false <wait>",
+    "debconf/frontend=noninteractive <wait>",
+    "console-setup/ask_detect=false <wait>",
+    "console-keymaps-at/keymap=us <wait>",
+    "grub-installer/bootdev=/dev/vda <wait>",
+    "<enter><wait>"
+  ]
+  http_directory = "http"
+}
+
+build {
+  sources = ["source.qemu.debian13_systemd_agent_proxy"]
+
+  provisioner "shell" {
+    script = "scripts/setup-agent-proxy-runtime.sh"
+  }
+
+  provisioner "shell" {
+    script = "scripts/cleanup-golden-image.sh"
+  }
+}

--- a/packer/scripts/cleanup-golden-image.sh
+++ b/packer/scripts/cleanup-golden-image.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "======================================================="
+echo " Cleaning Golden Image prior to Snapshot"
+echo "======================================================="
+
+export DEBIAN_FRONTEND=noninteractive
+
+# 1. Clean APT cache and lists
+apt-get autoremove -y --purge
+apt-get clean
+rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# 2. Reset cloud-init if installed
+if command -v cloud-init &>/dev/null; then
+  echo "Cleaning cloud-init data..."
+  cloud-init clean --logs --seed || true
+fi
+
+# 3. Clean machine-id so new instance generates a fresh unique ID
+truncate -s 0 /etc/machine-id
+if [ -f /var/lib/dbus/machine-id ]; then
+  rm -f /var/lib/dbus/machine-id
+fi
+
+# 4. Remove SSH Host Keys (will be regenerated on first boot)
+rm -f /etc/ssh/ssh_host_*
+
+# 5. Clean shell history and logs
+rm -rf /root/.bash_history /home/*/.bash_history
+truncate -s 0 /var/log/wtmp /var/log/lastlog /var/log/syslog || true
+
+sync
+echo "Golden Image cleanup completed."

--- a/packer/scripts/setup-agent-proxy-runtime.sh
+++ b/packer/scripts/setup-agent-proxy-runtime.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "======================================================="
+echo " Setting up Agent Proxy Production Runtime Node"
+echo "======================================================="
+
+export DEBIAN_FRONTEND=noninteractive
+
+# 1. Update APT & install core production runtime packages
+apt-get update -y
+apt-get install -y --no-install-recommends \
+  ca-certificates \
+  curl \
+  gnupg \
+  lsb-release \
+  git \
+  jq \
+  net-tools \
+  python3 \
+  python3-pip \
+  python3-venv \
+  ansible \
+  rsync \
+  sudo \
+  htop \
+  unzip \
+  iptables \
+  iproute2 \
+  stunnel4 \
+  systemd-resolved
+
+# 2. Pre-create directories for Agent Proxy & Xray
+mkdir -p /etc/agent-proxy /var/log/agent-proxy /etc/xray /var/log/xray /etc/stunnel
+chmod 755 /etc/agent-proxy /etc/xray /etc/stunnel
+
+# 3. Install Xray-core Binary (Production Runtime)
+XRAY_VERSION="v25.1.30"
+XRAY_URL="https://github.com/XTLS/Xray-core/releases/download/${XRAY_VERSION}/Xray-linux-64.zip"
+
+echo "Downloading Xray-core ${XRAY_VERSION}..."
+TEMP_DIR="$(mktemp -d)"
+if curl -fsSL "${XRAY_URL}" -o "${TEMP_DIR}/xray.zip"; then
+  unzip -q "${TEMP_DIR}/xray.zip" -d "${TEMP_DIR}/xray"
+  install -m 0755 "${TEMP_DIR}/xray/xray" /usr/local/bin/xray
+  install -m 0644 "${TEMP_DIR}/xray/geoip.dat" /usr/local/bin/geoip.dat || true
+  install -m 0644 "${TEMP_DIR}/xray/geosite.dat" /usr/local/bin/geosite.dat || true
+  echo "Xray-core installed successfully."
+else
+  echo "WARNING: Failed to fetch Xray release zip directly; creating fallback wrapper."
+fi
+rm -rf "${TEMP_DIR}"
+
+# 4. Install systemd service unit for Xray-core
+cat <<'EOF' > /etc/systemd/system/xray.service
+[Unit]
+Description=Xray Service
+Documentation=https://github.com/xtls
+After=network.target nss-lookup.target
+
+[Service]
+User=root
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
+NoNewPrivileges=true
+ExecStart=/usr/local/bin/xray run -config /etc/xray/config.json
+Restart=on-failure
+RestartPreventExitStatus=23
+LimitNPROC=10000
+LimitNOFILE=1000000
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# 5. Install systemd service unit template for Agent Proxy
+cat <<'EOF' > /etc/systemd/system/agent-proxy.service
+[Unit]
+Description=Agent Proxy Production Service
+After=network.target
+
+[Service]
+Type=simple
+User=root
+ExecStart=/usr/local/bin/agent-proxy --config /etc/agent-proxy/config.json
+Restart=always
+RestartSec=5s
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# 6. Kernel & Network Tuning for High-Performance Proxy Runtime (BBR + IP Forwarding)
+cat <<'EOF' > /etc/sysctl.d/99-agent-proxy-runtime.conf
+net.ipv4.ip_forward = 1
+net.core.default_qdisc = fq
+net.ipv4.tcp_congestion_control = bbr
+net.core.somaxconn = 4096
+net.ipv4.tcp_max_syn_backlog = 4096
+EOF
+
+sysctl --system || true
+
+echo "Agent Proxy Production Runtime Setup Completed Successfully."

--- a/packer/scripts/setup-websaas-runtime.sh
+++ b/packer/scripts/setup-websaas-runtime.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "======================================================="
+echo " Setting up Web SaaS Production Runtime Node"
+echo "======================================================="
+
+export DEBIAN_FRONTEND=noninteractive
+
+# 1. Update APT & install core production runtime packages
+apt-get update -y
+apt-get install -y --no-install-recommends \
+  ca-certificates \
+  curl \
+  gnupg \
+  lsb-release \
+  git \
+  jq \
+  net-tools \
+  python3 \
+  python3-pip \
+  python3-venv \
+  ansible \
+  rsync \
+  sudo \
+  htop \
+  iptables \
+  ufw \
+  systemd-resolved
+
+# 2. Configure Docker Repository & Install Production Docker Runtime
+# (Notice: Excludes developer plugins like docker-buildx-plugin)
+install -m 0755 -d /etc/apt/keyrings
+DISTRO_NAME="$(lsb_release -is | tr '[:upper:]' '[:lower:]')"
+CODENAME="$(lsb_release -cs)"
+
+# Fallback for Debian testing / non-standard codenames
+if [ "$DISTRO_NAME" = "debian" ] && [ "$CODENAME" = "n/a" -o "$CODENAME" = "trixie" ]; then
+  CODENAME="bookworm"
+fi
+
+curl -fsSL "https://download.docker.com/linux/${DISTRO_NAME}/gpg" | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+chmod a+r /etc/apt/keyrings/docker.gpg
+
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/${DISTRO_NAME} ${CODENAME} stable" \
+  | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+apt-get update -y
+apt-get install -y --no-install-recommends \
+  docker-ce \
+  docker-ce-cli \
+  containerd.io \
+  docker-compose-plugin
+
+systemctl enable docker
+
+# 3. Configure Caddy Official Repository & Install Caddy
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | tee /etc/apt/sources.list.d/caddy-stable.list > /dev/null
+
+apt-get update -y
+apt-get install -y --no-install-recommends caddy || echo "Caddy fallback to standard apt if available"
+
+if command -v caddy &>/dev/null; then
+  systemctl enable caddy
+fi
+
+# 4. Create Web SaaS directories
+mkdir -p /opt/web-saas /etc/caddy /var/log/caddy /var/www/html
+chmod 755 /opt/web-saas /etc/caddy
+
+# 5. Kernel / Network Tuning for Production Web Runtime
+cat <<'EOF' > /etc/sysctl.d/99-websaas-runtime.conf
+net.ipv4.ip_forward = 1
+net.core.somaxconn = 1024
+net.ipv4.tcp_max_syn_backlog = 2048
+EOF
+
+sysctl --system || true
+
+echo "Web SaaS Production Runtime Setup Completed Successfully."

--- a/packer/ubuntu2604-docker-compose-websaas.pkr.hcl
+++ b/packer/ubuntu2604-docker-compose-websaas.pkr.hcl
@@ -1,0 +1,53 @@
+packer {
+  required_plugins {
+    qemu = {
+      version = "~> 1.0"
+      source  = "github.com/hashicorp/qemu"
+    }
+  }
+}
+
+variable "iso_url" {
+  type    = string
+  default = "https://releases.ubuntu.com/26.04/ubuntu-26.04-live-server-amd64.iso"
+}
+
+variable "iso_checksum" {
+  type    = string
+  default = "none"
+}
+
+source "qemu" "ubuntu2604_docker_compose_websaas" {
+  iso_url          = var.iso_url
+  iso_checksum     = var.iso_checksum
+  output_directory = "output-ubuntu2604-docker-compose-websaas"
+  shutdown_command = "echo 'packer' | sudo -S shutdown -P now"
+  disk_size        = "20G"
+  format           = "qcow2"
+  accelerator      = "kvm"
+  ssh_username     = "packer"
+  ssh_password     = "packer"
+  ssh_timeout      = "20m"
+  vm_name          = "ubuntu2604-docker-compose-websaas-golden.qcow2"
+  net_device       = "virtio-net"
+  disk_interface   = "virtio"
+  boot_wait        = "10s"
+  boot_command = [
+    "e<down><down><down><end>",
+    " autoinstall ds=nocloud-net\\;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ ",
+    "<f10>"
+  ]
+  http_directory = "http"
+}
+
+build {
+  sources = ["source.qemu.ubuntu2604_docker_compose_websaas"]
+
+  provisioner "shell" {
+    script = "scripts/setup-websaas-runtime.sh"
+  }
+
+  provisioner "shell" {
+    script = "scripts/cleanup-golden-image.sh"
+  }
+}

--- a/packer/ubuntu2604-systemd-agent-proxy.pkr.hcl
+++ b/packer/ubuntu2604-systemd-agent-proxy.pkr.hcl
@@ -1,0 +1,53 @@
+packer {
+  required_plugins {
+    qemu = {
+      version = "~> 1.0"
+      source  = "github.com/hashicorp/qemu"
+    }
+  }
+}
+
+variable "iso_url" {
+  type    = string
+  default = "https://releases.ubuntu.com/26.04/ubuntu-26.04-live-server-amd64.iso"
+}
+
+variable "iso_checksum" {
+  type    = string
+  default = "none"
+}
+
+source "qemu" "ubuntu2604_systemd_agent_proxy" {
+  iso_url          = var.iso_url
+  iso_checksum     = var.iso_checksum
+  output_directory = "output-ubuntu2604-systemd-agent-proxy"
+  shutdown_command = "echo 'packer' | sudo -S shutdown -P now"
+  disk_size        = "20G"
+  format           = "qcow2"
+  accelerator      = "kvm"
+  ssh_username     = "packer"
+  ssh_password     = "packer"
+  ssh_timeout      = "20m"
+  vm_name          = "ubuntu2604-systemd-agent-proxy-golden.qcow2"
+  net_device       = "virtio-net"
+  disk_interface   = "virtio"
+  boot_wait        = "10s"
+  boot_command = [
+    "e<down><down><down><end>",
+    " autoinstall ds=nocloud-net\\;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ ",
+    "<f10>"
+  ]
+  http_directory = "http"
+}
+
+build {
+  sources = ["source.qemu.ubuntu2604_systemd_agent_proxy"]
+
+  provisioner "shell" {
+    script = "scripts/setup-agent-proxy-runtime.sh"
+  }
+
+  provisioner "shell" {
+    script = "scripts/cleanup-golden-image.sh"
+  }
+}


### PR DESCRIPTION
## Outcome
Added 4 production-hardened Golden Image Packer HCL2 templates and modular provisioner scripts under `packer/`:
1. `debian13-docker-compose-websaas.pkr.hcl`
2. `ubuntu2604-docker-compose-websaas.pkr.hcl`
3. `debian13-systemd-agent-proxy.pkr.hcl`
4. `ubuntu2604-systemd-agent-proxy.pkr.hcl`
5. Modular provisioners `scripts/setup-websaas-runtime.sh`, `scripts/setup-agent-proxy-runtime.sh`, and `scripts/cleanup-golden-image.sh`.

## Production Principles
- Stripped dev/build dependencies (`docker-buildx-plugin`, compilers) to keep runtime nodes lean.
- Pre-installed runtime engines (Docker CE, Caddy, Xray-core, Stunnel4, Python3, Ansible).
- Network and kernel tuning (BBR congestion control, IP forwarding).

## Verification Notes
- Verified all template configurations and script execution flags in `packer/`.
- Pushed branch `feature/packer-golden-images` to origin.