### PR TITLE
feat(packer): publish golden images to Vultr

### DIFF
--- a/.github/scripts/packer-vultr-build.sh
+++ b/.github/scripts/packer-vultr-build.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${TEMPLATE:?TEMPLATE must be set}"
+: "${SOURCE_NAME:?SOURCE_NAME must be set}"
+: "${VULTR_API_KEY:?VULTR_API_KEY must be set}"
+: "${VULTR_REGION_ID:?VULTR_REGION_ID must be set}"
+: "${VULTR_PLAN_ID:?VULTR_PLAN_ID must be set}"
+: "${VULTR_OS_REGEX:?VULTR_OS_REGEX must be set}"
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "${script_dir}/../.." && pwd)"
+
+template_path="$TEMPLATE"
+template_path="${template_path#packer/}"
+cd "${repo_root}/packer"
+
+for command_name in curl jq packer tee; do
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "Required command is not installed: ${command_name}" >&2
+    exit 1
+  fi
+done
+
+if [[ ! -f "$template_path" ]]; then
+  echo "Packer template does not exist: ${repo_root}/packer/${template_path}" >&2
+  exit 1
+fi
+
+os_id="${VULTR_OS_ID:-}"
+if [[ -z "$os_id" ]]; then
+  os_id="$("${script_dir}/resolve-vultr-os-id.sh" "$VULTR_OS_REGEX")"
+fi
+
+if [[ ! "$os_id" =~ ^[0-9]+$ || "$os_id" == "0" ]]; then
+  echo "VULTR_OS_ID must be a positive numeric Vultr OS ID, got: ${os_id}" >&2
+  exit 1
+fi
+
+snapshot_description="${VULTR_SNAPSHOT_DESCRIPTION:-golden-${SOURCE_NAME}-${GITHUB_RUN_ID:-local}}"
+packer_log="${PACKER_LOG:-packer-${SOURCE_NAME}.log}"
+if [[ "$packer_log" != /* ]]; then
+  packer_log="${repo_root}/${packer_log}"
+fi
+
+packer init "$template_path"
+
+packer_vars=(
+  "-var=vultr_os_id=${os_id}"
+  "-var=vultr_region_id=${VULTR_REGION_ID}"
+  "-var=vultr_plan_id=${VULTR_PLAN_ID}"
+  "-var=vultr_snapshot_description=${snapshot_description}"
+)
+
+packer validate "${packer_vars[@]}" "$template_path"
+
+echo "Building ${TEMPLATE} with Vultr source ${SOURCE_NAME}"
+echo "Vultr region=${VULTR_REGION_ID}, plan=${VULTR_PLAN_ID}, os_id=${os_id}"
+echo "Snapshot description=${snapshot_description}"
+
+packer build -color=false -only="vultr.${SOURCE_NAME}" "${packer_vars[@]}" "$template_path" \
+  2>&1 | tee "$packer_log"
+
+snapshot_id="$(sed -nE 's/.*Vultr Snapshot: .* \(([[:alnum:]-]+)\).*/\1/p' "$packer_log" | tail -n 1)"
+if [[ -z "$snapshot_id" ]]; then
+  snapshot_id="$(curl --silent --show-error --fail --compressed \
+    --header "Authorization: Bearer ${VULTR_API_KEY}" \
+    --header "Content-Type: application/json" \
+    "https://api.vultr.com/v2/snapshots" \
+    | jq -r --arg description "$snapshot_description" '
+      .snapshots[] | select(.description == $description) | .id
+    ' | head -n 1)"
+fi
+
+if [[ -z "$snapshot_id" || "$snapshot_id" == "null" ]]; then
+  echo "Packer completed, but the Vultr snapshot ID could not be determined." >&2
+  exit 1
+fi
+
+snapshot_status="$(curl --silent --show-error --fail --compressed \
+  --header "Authorization: Bearer ${VULTR_API_KEY}" \
+  --header "Content-Type: application/json" \
+  "https://api.vultr.com/v2/snapshots/${snapshot_id}" \
+  | jq -r '.snapshot.status')"
+
+if [[ "$snapshot_status" != "complete" ]]; then
+  echo "Vultr snapshot ${snapshot_id} is not complete: ${snapshot_status}" >&2
+  exit 1
+fi
+
+echo "Vultr snapshot published: ${snapshot_id}"
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo "snapshot_id=${snapshot_id}"
+    echo "os_id=${os_id}"
+    echo "snapshot_description=${snapshot_description}"
+  } >>"$GITHUB_OUTPUT"
+fi
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  {
+    echo "## Vultr Golden Image"
+    echo
+    echo "- Template: \`${TEMPLATE}\`"
+    echo "- Snapshot ID: \`${snapshot_id}\`"
+    echo "- Snapshot description: \`${snapshot_description}\`"
+    echo "- Region: \`${VULTR_REGION_ID}\`"
+    echo "- Plan: \`${VULTR_PLAN_ID}\`"
+    echo "- OS ID: \`${os_id}\`"
+  } >>"$GITHUB_STEP_SUMMARY"
+fi

--- a/.github/scripts/resolve-vultr-os-id.sh
+++ b/.github/scripts/resolve-vultr-os-id.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 || -z "$1" ]]; then
+  echo "usage: $0 <OS-name-regex>" >&2
+  exit 2
+fi
+
+: "${VULTR_API_KEY:?VULTR_API_KEY must be set}"
+
+os_name_regex="$1"
+api_response="$(curl --silent --show-error --fail --compressed \
+  --header "Authorization: Bearer ${VULTR_API_KEY}" \
+  --header "Content-Type: application/json" \
+  "https://api.vultr.com/v2/os")"
+
+os_id="$(jq -r --arg pattern "$os_name_regex" '
+  .os[]
+  | select((.arch == "x64" or .arch == "x86_64") and (.name | test($pattern; "i")))
+  | .id
+' <<<"$api_response" | head -n 1)"
+
+if [[ -z "$os_id" || "$os_id" == "null" ]]; then
+  echo "No x64 Vultr OS matched regex: ${os_name_regex}" >&2
+  echo "Available matching candidates:" >&2
+  jq -r --arg pattern "$os_name_regex" '
+    .os[] | select(.name | test($pattern; "i")) | "\(.id)\t\(.name)\t\(.arch)"
+  ' <<<"$api_response" >&2
+  exit 1
+fi
+
+echo "$os_id"

--- a/.github/workflows/packer-vultr-debian13-docker-compose-websaas.yml
+++ b/.github/workflows/packer-vultr-debian13-docker-compose-websaas.yml
@@ -1,0 +1,51 @@
+name: Publish Debian 13 Web SaaS Golden Image to Vultr
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - packer/debian13-docker-compose-websaas.pkr.hcl
+      - packer/scripts/setup-websaas-runtime.sh
+      - packer/scripts/cleanup-golden-image.sh
+      - .github/scripts/**
+      - .github/workflows/packer-vultr-debian13-docker-compose-websaas.yml
+      - .github/workflows/packer-vultr-publish-reusable.yml
+  workflow_dispatch:
+    inputs:
+      region_id:
+        description: Vultr region used for the temporary builder VPS
+        required: true
+        default: ewr
+        type: string
+      plan_id:
+        description: Vultr plan used for the temporary builder VPS
+        required: true
+        default: vc2-2c-4gb
+        type: string
+      os_id:
+        description: Optional Vultr OS ID override; blank resolves Debian 13 x64
+        required: false
+        default: ''
+        type: string
+      runner:
+        description: GitHub runner
+        required: true
+        default: ubuntu-latest
+        type: choice
+        options: [ubuntu-latest, self-runner]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    uses: ./.github/workflows/packer-vultr-publish-reusable.yml
+    with:
+      template: packer/debian13-docker-compose-websaas.pkr.hcl
+      source_name: debian13_docker_compose_websaas
+      os_regex: '^Debian 13'
+      region_id: ${{ inputs.region_id || 'ewr' }}
+      plan_id: ${{ inputs.plan_id || 'vc2-2c-4gb' }}
+      os_id: ${{ inputs.os_id || '' }}
+      runner: ${{ inputs.runner || 'ubuntu-latest' }}

--- a/.github/workflows/packer-vultr-debian13-systemd-agent-proxy.yml
+++ b/.github/workflows/packer-vultr-debian13-systemd-agent-proxy.yml
@@ -1,0 +1,51 @@
+name: Publish Debian 13 Agent Proxy Golden Image to Vultr
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - packer/debian13-systemd-agent-proxy.pkr.hcl
+      - packer/scripts/setup-agent-proxy-runtime.sh
+      - packer/scripts/cleanup-golden-image.sh
+      - .github/scripts/**
+      - .github/workflows/packer-vultr-debian13-systemd-agent-proxy.yml
+      - .github/workflows/packer-vultr-publish-reusable.yml
+  workflow_dispatch:
+    inputs:
+      region_id:
+        description: Vultr region used for the temporary builder VPS
+        required: true
+        default: ewr
+        type: string
+      plan_id:
+        description: Vultr plan used for the temporary builder VPS
+        required: true
+        default: vc2-2c-4gb
+        type: string
+      os_id:
+        description: Optional Vultr OS ID override; blank resolves Debian 13 x64
+        required: false
+        default: ''
+        type: string
+      runner:
+        description: GitHub runner
+        required: true
+        default: ubuntu-latest
+        type: choice
+        options: [ubuntu-latest, self-runner]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    uses: ./.github/workflows/packer-vultr-publish-reusable.yml
+    with:
+      template: packer/debian13-systemd-agent-proxy.pkr.hcl
+      source_name: debian13_systemd_agent_proxy
+      os_regex: '^Debian 13'
+      region_id: ${{ inputs.region_id || 'ewr' }}
+      plan_id: ${{ inputs.plan_id || 'vc2-2c-4gb' }}
+      os_id: ${{ inputs.os_id || '' }}
+      runner: ${{ inputs.runner || 'ubuntu-latest' }}

--- a/.github/workflows/packer-vultr-publish-reusable.yml
+++ b/.github/workflows/packer-vultr-publish-reusable.yml
@@ -1,0 +1,82 @@
+name: Reusable Vultr Golden Image Publisher
+
+on:
+  workflow_call:
+    inputs:
+      template:
+        required: true
+        type: string
+      source_name:
+        required: true
+        type: string
+      os_regex:
+        required: true
+        type: string
+      region_id:
+        required: false
+        default: ewr
+        type: string
+      plan_id:
+        required: false
+        default: vc2-2c-4gb
+        type: string
+      os_id:
+        required: false
+        default: ''
+        type: string
+      runner:
+        required: false
+        default: ubuntu-latest
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: vultr-golden-image-${{ inputs.source_name }}-uat
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish ${{ inputs.source_name }} to Vultr (uat)
+    runs-on: ${{ inputs.runner }}
+    environment: uat
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Packer
+        uses: hashicorp/setup-packer@v3
+
+      - name: Load Vultr API key from Vault
+        id: vault
+        uses: hashicorp/vault-action@v3
+        with:
+          url: ${{ vars.VAULT_ADDR || 'https://vault.svc.plus' }}
+          method: jwt
+          path: jwt
+          role: github-actions-artifacts-uat
+          secrets: |
+            kv/data/CICD/uat VULTR_API_KEY | VULTR_API_KEY
+
+      - name: Build and publish Vultr snapshot
+        id: packer
+        env:
+          TEMPLATE: ${{ inputs.template }}
+          SOURCE_NAME: ${{ inputs.source_name }}
+          VULTR_API_KEY: ${{ steps.vault.outputs.VULTR_API_KEY }}
+          VULTR_REGION_ID: ${{ inputs.region_id }}
+          VULTR_PLAN_ID: ${{ inputs.plan_id }}
+          VULTR_OS_ID: ${{ inputs.os_id }}
+          VULTR_OS_REGEX: ${{ inputs.os_regex }}
+          PACKER_LOG: packer-${{ inputs.source_name }}.log
+        run: bash .github/scripts/packer-vultr-build.sh
+
+      - name: Upload Packer log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: packer-${{ inputs.source_name }}-${{ github.run_id }}
+          path: packer-${{ inputs.source_name }}.log
+          if-no-files-found: ignore

--- a/.github/workflows/packer-vultr-ubuntu2604-docker-compose-websaas.yml
+++ b/.github/workflows/packer-vultr-ubuntu2604-docker-compose-websaas.yml
@@ -1,0 +1,51 @@
+name: Publish Ubuntu 26.04 Web SaaS Golden Image to Vultr
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - packer/ubuntu2604-docker-compose-websaas.pkr.hcl
+      - packer/scripts/setup-websaas-runtime.sh
+      - packer/scripts/cleanup-golden-image.sh
+      - .github/scripts/**
+      - .github/workflows/packer-vultr-ubuntu2604-docker-compose-websaas.yml
+      - .github/workflows/packer-vultr-publish-reusable.yml
+  workflow_dispatch:
+    inputs:
+      region_id:
+        description: Vultr region used for the temporary builder VPS
+        required: true
+        default: ewr
+        type: string
+      plan_id:
+        description: Vultr plan used for the temporary builder VPS
+        required: true
+        default: vc2-2c-4gb
+        type: string
+      os_id:
+        description: Optional Vultr OS ID override; blank resolves Ubuntu 26.04 x64
+        required: false
+        default: ''
+        type: string
+      runner:
+        description: GitHub runner
+        required: true
+        default: ubuntu-latest
+        type: choice
+        options: [ubuntu-latest, self-runner]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    uses: ./.github/workflows/packer-vultr-publish-reusable.yml
+    with:
+      template: packer/ubuntu2604-docker-compose-websaas.pkr.hcl
+      source_name: ubuntu2604_docker_compose_websaas
+      os_regex: '^Ubuntu 26\.04'
+      region_id: ${{ inputs.region_id || 'ewr' }}
+      plan_id: ${{ inputs.plan_id || 'vc2-2c-4gb' }}
+      os_id: ${{ inputs.os_id || '' }}
+      runner: ${{ inputs.runner || 'ubuntu-latest' }}

--- a/.github/workflows/packer-vultr-ubuntu2604-systemd-agent-proxy.yml
+++ b/.github/workflows/packer-vultr-ubuntu2604-systemd-agent-proxy.yml
@@ -1,0 +1,51 @@
+name: Publish Ubuntu 26.04 Agent Proxy Golden Image to Vultr
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - packer/ubuntu2604-systemd-agent-proxy.pkr.hcl
+      - packer/scripts/setup-agent-proxy-runtime.sh
+      - packer/scripts/cleanup-golden-image.sh
+      - .github/scripts/**
+      - .github/workflows/packer-vultr-ubuntu2604-systemd-agent-proxy.yml
+      - .github/workflows/packer-vultr-publish-reusable.yml
+  workflow_dispatch:
+    inputs:
+      region_id:
+        description: Vultr region used for the temporary builder VPS
+        required: true
+        default: ewr
+        type: string
+      plan_id:
+        description: Vultr plan used for the temporary builder VPS
+        required: true
+        default: vc2-2c-4gb
+        type: string
+      os_id:
+        description: Optional Vultr OS ID override; blank resolves Ubuntu 26.04 x64
+        required: false
+        default: ''
+        type: string
+      runner:
+        description: GitHub runner
+        required: true
+        default: ubuntu-latest
+        type: choice
+        options: [ubuntu-latest, self-runner]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    uses: ./.github/workflows/packer-vultr-publish-reusable.yml
+    with:
+      template: packer/ubuntu2604-systemd-agent-proxy.pkr.hcl
+      source_name: ubuntu2604_systemd_agent_proxy
+      os_regex: '^Ubuntu 26\.04'
+      region_id: ${{ inputs.region_id || 'ewr' }}
+      plan_id: ${{ inputs.plan_id || 'vc2-2c-4gb' }}
+      os_id: ${{ inputs.os_id || '' }}
+      runner: ${{ inputs.runner || 'ubuntu-latest' }}

--- a/packer/README.md
+++ b/packer/README.md
@@ -1,0 +1,38 @@
+# Golden Image 发布
+
+本目录的四个 Web SaaS / Agent Proxy 模板同时保留 QEMU 本地构建和 Vultr 构建入口。Vultr 构建使用官方 `github.com/vultr/vultr` Packer plugin：临时创建 Vultr VPS，执行 runtime provisioner，生成 Snapshot，然后销毁临时 VPS。AWS、GCP、Azure、AliCloud 的现有模板和 workflow 不会被替换。
+
+## Vultr workflow
+
+`.github/workflows/` 下有四个按模板拆分的发布入口：
+
+- `packer-vultr-debian13-docker-compose-websaas.yml`
+- `packer-vultr-ubuntu2604-docker-compose-websaas.yml`
+- `packer-vultr-debian13-systemd-agent-proxy.yml`
+- `packer-vultr-ubuntu2604-systemd-agent-proxy.yml`
+
+手动运行时可选择 Vultr region、临时构建 VPS plan，并可用 `os_id` 覆盖动态 OS ID 解析。合并到 `main` 后，模板变更会自动走 UAT 发布。
+
+## Vault prerequisites
+
+工作流使用 GitHub OIDC 登录 Vault，不从 GitHub Actions Secrets 读取 Vultr API key。UAT 需要在下面的 Vault 路径提供 `VULTR_API_KEY`：
+
+```text
+kv/data/CICD/uat
+```
+
+对应的 JWT role 约定为 `github-actions-artifacts-uat`。Vault policy 只授予当前仓库读取该 UAT 路径的权限。
+
+## Local validation
+
+```bash
+VULTR_API_KEY=... \
+VULTR_REGION_ID=ewr \
+VULTR_PLAN_ID=vc2-2c-4gb \
+VULTR_OS_REGEX='^Debian 13' \
+TEMPLATE=packer/debian13-docker-compose-websaas.pkr.hcl \
+SOURCE_NAME=debian13_docker_compose_websaas \
+bash .github/scripts/packer-vultr-build.sh
+```
+
+本地执行会真实创建 Vultr 临时 VPS 和 Snapshot；只做语法校验时请使用 `packer init` / `packer validate`，不要执行 `packer build`。

--- a/packer/debian13-docker-compose-websaas.pkr.hcl
+++ b/packer/debian13-docker-compose-websaas.pkr.hcl
@@ -4,6 +4,10 @@ packer {
       version = "~> 1.0"
       source  = "github.com/hashicorp/qemu"
     }
+    vultr = {
+      version = ">= 2.3.2"
+      source  = "github.com/vultr/vultr"
+    }
   }
 }
 
@@ -15,6 +19,32 @@ variable "iso_url" {
 variable "iso_checksum" {
   type    = string
   default = "none"
+}
+
+variable "vultr_api_key" {
+  type      = string
+  sensitive = true
+  default   = env("VULTR_API_KEY")
+}
+
+variable "vultr_os_id" {
+  type    = number
+  default = 0
+}
+
+variable "vultr_region_id" {
+  type    = string
+  default = "ewr"
+}
+
+variable "vultr_plan_id" {
+  type    = string
+  default = "vc2-2c-4gb"
+}
+
+variable "vultr_snapshot_description" {
+  type    = string
+  default = "debian13-docker-compose-websaas-golden"
 }
 
 source "qemu" "debian13_docker_compose_websaas" {
@@ -55,6 +85,30 @@ source "qemu" "debian13_docker_compose_websaas" {
 
 build {
   sources = ["source.qemu.debian13_docker_compose_websaas"]
+
+  provisioner "shell" {
+    script = "scripts/setup-websaas-runtime.sh"
+  }
+
+  provisioner "shell" {
+    script = "scripts/cleanup-golden-image.sh"
+  }
+}
+
+source "vultr" "debian13_docker_compose_websaas" {
+  api_key              = var.vultr_api_key
+  os_id                = var.vultr_os_id
+  plan_id              = var.vultr_plan_id
+  region_id            = var.vultr_region_id
+  instance_label       = "packer-debian13-docker-compose-websaas"
+  snapshot_description = var.vultr_snapshot_description
+  state_timeout        = "30m"
+  ssh_username         = "root"
+  ssh_timeout          = "20m"
+}
+
+build {
+  sources = ["source.vultr.debian13_docker_compose_websaas"]
 
   provisioner "shell" {
     script = "scripts/setup-websaas-runtime.sh"

--- a/packer/debian13-systemd-agent-proxy.pkr.hcl
+++ b/packer/debian13-systemd-agent-proxy.pkr.hcl
@@ -4,6 +4,10 @@ packer {
       version = "~> 1.0"
       source  = "github.com/hashicorp/qemu"
     }
+    vultr = {
+      version = ">= 2.3.2"
+      source  = "github.com/vultr/vultr"
+    }
   }
 }
 
@@ -15,6 +19,32 @@ variable "iso_url" {
 variable "iso_checksum" {
   type    = string
   default = "none"
+}
+
+variable "vultr_api_key" {
+  type      = string
+  sensitive = true
+  default   = env("VULTR_API_KEY")
+}
+
+variable "vultr_os_id" {
+  type    = number
+  default = 0
+}
+
+variable "vultr_region_id" {
+  type    = string
+  default = "ewr"
+}
+
+variable "vultr_plan_id" {
+  type    = string
+  default = "vc2-2c-4gb"
+}
+
+variable "vultr_snapshot_description" {
+  type    = string
+  default = "debian13-systemd-agent-proxy-golden"
 }
 
 source "qemu" "debian13_systemd_agent_proxy" {
@@ -55,6 +85,30 @@ source "qemu" "debian13_systemd_agent_proxy" {
 
 build {
   sources = ["source.qemu.debian13_systemd_agent_proxy"]
+
+  provisioner "shell" {
+    script = "scripts/setup-agent-proxy-runtime.sh"
+  }
+
+  provisioner "shell" {
+    script = "scripts/cleanup-golden-image.sh"
+  }
+}
+
+source "vultr" "debian13_systemd_agent_proxy" {
+  api_key              = var.vultr_api_key
+  os_id                = var.vultr_os_id
+  plan_id              = var.vultr_plan_id
+  region_id            = var.vultr_region_id
+  instance_label       = "packer-debian13-systemd-agent-proxy"
+  snapshot_description = var.vultr_snapshot_description
+  state_timeout        = "30m"
+  ssh_username         = "root"
+  ssh_timeout          = "20m"
+}
+
+build {
+  sources = ["source.vultr.debian13_systemd_agent_proxy"]
 
   provisioner "shell" {
     script = "scripts/setup-agent-proxy-runtime.sh"

--- a/packer/ubuntu2604-docker-compose-websaas.pkr.hcl
+++ b/packer/ubuntu2604-docker-compose-websaas.pkr.hcl
@@ -4,6 +4,10 @@ packer {
       version = "~> 1.0"
       source  = "github.com/hashicorp/qemu"
     }
+    vultr = {
+      version = ">= 2.3.2"
+      source  = "github.com/vultr/vultr"
+    }
   }
 }
 
@@ -15,6 +19,32 @@ variable "iso_url" {
 variable "iso_checksum" {
   type    = string
   default = "none"
+}
+
+variable "vultr_api_key" {
+  type      = string
+  sensitive = true
+  default   = env("VULTR_API_KEY")
+}
+
+variable "vultr_os_id" {
+  type    = number
+  default = 0
+}
+
+variable "vultr_region_id" {
+  type    = string
+  default = "ewr"
+}
+
+variable "vultr_plan_id" {
+  type    = string
+  default = "vc2-2c-4gb"
+}
+
+variable "vultr_snapshot_description" {
+  type    = string
+  default = "ubuntu2604-docker-compose-websaas-golden"
 }
 
 source "qemu" "ubuntu2604_docker_compose_websaas" {
@@ -42,6 +72,30 @@ source "qemu" "ubuntu2604_docker_compose_websaas" {
 
 build {
   sources = ["source.qemu.ubuntu2604_docker_compose_websaas"]
+
+  provisioner "shell" {
+    script = "scripts/setup-websaas-runtime.sh"
+  }
+
+  provisioner "shell" {
+    script = "scripts/cleanup-golden-image.sh"
+  }
+}
+
+source "vultr" "ubuntu2604_docker_compose_websaas" {
+  api_key              = var.vultr_api_key
+  os_id                = var.vultr_os_id
+  plan_id              = var.vultr_plan_id
+  region_id            = var.vultr_region_id
+  instance_label       = "packer-ubuntu2604-docker-compose-websaas"
+  snapshot_description = var.vultr_snapshot_description
+  state_timeout        = "30m"
+  ssh_username         = "root"
+  ssh_timeout          = "20m"
+}
+
+build {
+  sources = ["source.vultr.ubuntu2604_docker_compose_websaas"]
 
   provisioner "shell" {
     script = "scripts/setup-websaas-runtime.sh"

--- a/packer/ubuntu2604-systemd-agent-proxy.pkr.hcl
+++ b/packer/ubuntu2604-systemd-agent-proxy.pkr.hcl
@@ -4,6 +4,10 @@ packer {
       version = "~> 1.0"
       source  = "github.com/hashicorp/qemu"
     }
+    vultr = {
+      version = ">= 2.3.2"
+      source  = "github.com/vultr/vultr"
+    }
   }
 }
 
@@ -15,6 +19,32 @@ variable "iso_url" {
 variable "iso_checksum" {
   type    = string
   default = "none"
+}
+
+variable "vultr_api_key" {
+  type      = string
+  sensitive = true
+  default   = env("VULTR_API_KEY")
+}
+
+variable "vultr_os_id" {
+  type    = number
+  default = 0
+}
+
+variable "vultr_region_id" {
+  type    = string
+  default = "ewr"
+}
+
+variable "vultr_plan_id" {
+  type    = string
+  default = "vc2-2c-4gb"
+}
+
+variable "vultr_snapshot_description" {
+  type    = string
+  default = "ubuntu2604-systemd-agent-proxy-golden"
 }
 
 source "qemu" "ubuntu2604_systemd_agent_proxy" {
@@ -42,6 +72,30 @@ source "qemu" "ubuntu2604_systemd_agent_proxy" {
 
 build {
   sources = ["source.qemu.ubuntu2604_systemd_agent_proxy"]
+
+  provisioner "shell" {
+    script = "scripts/setup-agent-proxy-runtime.sh"
+  }
+
+  provisioner "shell" {
+    script = "scripts/cleanup-golden-image.sh"
+  }
+}
+
+source "vultr" "ubuntu2604_systemd_agent_proxy" {
+  api_key              = var.vultr_api_key
+  os_id                = var.vultr_os_id
+  plan_id              = var.vultr_plan_id
+  region_id            = var.vultr_region_id
+  instance_label       = "packer-ubuntu2604-systemd-agent-proxy"
+  snapshot_description = var.vultr_snapshot_description
+  state_timeout        = "30m"
+  ssh_username         = "root"
+  ssh_timeout          = "20m"
+}
+
+build {
+  sources = ["source.vultr.ubuntu2604_systemd_agent_proxy"]
 
   provisioner "shell" {
     script = "scripts/setup-agent-proxy-runtime.sh"


### PR DESCRIPTION
## Outcome

- Adds Vultr Packer snapshot publishing for the four Debian 13 / Ubuntu 26.04 Web SaaS and Agent Proxy templates.
- Keeps the existing QEMU templates and existing AWS/GCP/Azure/AliCloud workflows intact.
- Uses GitHub OIDC to Vault and reads `kv/data/CICD/uat` key `VULTR_API_KEY`; no Vultr credential is stored in GitHub Actions Secrets.

## Issue

- No issue link was provided for this request.

## Verification

- Packer 1.16.0 `fmt -check` passed for all four templates.
- Packer 1.16.0 `validate` passed for all four templates.
- actionlint passed for all five new workflows.
- `bash -n` and `git diff --check` passed.

## Deployment behavior

- Merge to `main` triggers the four UAT Vultr workflows by path.
- Each workflow creates a temporary Vultr VPS, provisions it, creates a completed Vultr Snapshot, and destroys the temporary VPS.
