### PR TITLE
fix(packer): enhance DNS resolution stability and add retry flags in runtime provisioners

### DIFF
--- a/packer/scripts/setup-agent-proxy-runtime.sh
+++ b/packer/scripts/setup-agent-proxy-runtime.sh
@@ -7,6 +7,12 @@ echo "======================================================="
 
 export DEBIAN_FRONTEND=noninteractive
 
+# Ensure valid DNS resolvers exist
+if ! grep -q "nameserver" /etc/resolv.conf 2>/dev/null; then
+  echo "nameserver 1.1.1.1" >> /etc/resolv.conf
+  echo "nameserver 8.8.8.8" >> /etc/resolv.conf
+fi
+
 # 1. Update APT & install core production runtime packages
 apt-get update -y
 apt-get install -y --no-install-recommends \
@@ -27,8 +33,13 @@ apt-get install -y --no-install-recommends \
   unzip \
   iptables \
   iproute2 \
-  stunnel4 \
-  systemd-resolved
+  stunnel4
+
+# Ensure DNS remains valid after package installation
+if ! grep -q "nameserver" /etc/resolv.conf 2>/dev/null; then
+  echo "nameserver 1.1.1.1" >> /etc/resolv.conf
+  echo "nameserver 8.8.8.8" >> /etc/resolv.conf
+fi
 
 # 2. Pre-create directories for Agent Proxy & Xray
 mkdir -p /etc/agent-proxy /var/log/agent-proxy /etc/xray /var/log/xray /etc/stunnel
@@ -40,7 +51,7 @@ XRAY_URL="https://github.com/XTLS/Xray-core/releases/download/${XRAY_VERSION}/Xr
 
 echo "Downloading Xray-core ${XRAY_VERSION}..."
 TEMP_DIR="$(mktemp -d)"
-if curl -fsSL "${XRAY_URL}" -o "${TEMP_DIR}/xray.zip"; then
+if curl -fsSL --retry 5 --retry-delay 2 --retry-connrefused "${XRAY_URL}" -o "${TEMP_DIR}/xray.zip"; then
   unzip -q "${TEMP_DIR}/xray.zip" -d "${TEMP_DIR}/xray"
   install -m 0755 "${TEMP_DIR}/xray/xray" /usr/local/bin/xray
   install -m 0644 "${TEMP_DIR}/xray/geoip.dat" /usr/local/bin/geoip.dat || true

--- a/packer/scripts/setup-websaas-runtime.sh
+++ b/packer/scripts/setup-websaas-runtime.sh
@@ -7,6 +7,12 @@ echo "======================================================="
 
 export DEBIAN_FRONTEND=noninteractive
 
+# Ensure valid DNS resolvers exist
+if ! grep -q "nameserver" /etc/resolv.conf 2>/dev/null; then
+  echo "nameserver 1.1.1.1" >> /etc/resolv.conf
+  echo "nameserver 8.8.8.8" >> /etc/resolv.conf
+fi
+
 # 1. Update APT & install core production runtime packages
 apt-get update -y
 apt-get install -y --no-install-recommends \
@@ -25,8 +31,13 @@ apt-get install -y --no-install-recommends \
   sudo \
   htop \
   iptables \
-  ufw \
-  systemd-resolved
+  ufw
+
+# Ensure DNS remains valid after package installation
+if ! grep -q "nameserver" /etc/resolv.conf 2>/dev/null; then
+  echo "nameserver 1.1.1.1" >> /etc/resolv.conf
+  echo "nameserver 8.8.8.8" >> /etc/resolv.conf
+fi
 
 # 2. Configure Docker Repository & Install Production Docker Runtime
 # (Notice: Excludes developer plugins like docker-buildx-plugin)
@@ -39,7 +50,7 @@ if [ "$DISTRO_NAME" = "debian" ] && [ "$CODENAME" = "n/a" -o "$CODENAME" = "trix
   CODENAME="bookworm"
 fi
 
-curl -fsSL "https://download.docker.com/linux/${DISTRO_NAME}/gpg" | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+curl -fsSL --retry 5 --retry-delay 2 --retry-connrefused "https://download.docker.com/linux/${DISTRO_NAME}/gpg" | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 chmod a+r /etc/apt/keyrings/docker.gpg
 
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/${DISTRO_NAME} ${CODENAME} stable" \
@@ -55,8 +66,8 @@ apt-get install -y --no-install-recommends \
 systemctl enable docker
 
 # 3. Configure Caddy Official Repository & Install Caddy
-curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
-curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | tee /etc/apt/sources.list.d/caddy-stable.list > /dev/null
+curl -1sLf --retry 5 --retry-delay 2 --retry-connrefused 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+curl -1sLf --retry 5 --retry-delay 2 --retry-connrefused 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | tee /etc/apt/sources.list.d/caddy-stable.list > /dev/null
 
 apt-get update -y
 apt-get install -y --no-install-recommends caddy || echo "Caddy fallback to standard apt if available"


### PR DESCRIPTION
## Outcome
Fixed provisioner failure in Golden Image Packer builds where `curl: (6) Could not resolve host: download.docker.com` occurred during cloud VPS runtime setup.

## Root Cause & Fix
- Removed `systemd-resolved` package from the dynamic apt installation list, which altered/cleared `/etc/resolv.conf` before service startup on Debian/Ubuntu cloud VPS instances.
- Injected fallback DNS resolver checks (`1.1.1.1`, `8.8.8.8`) into `/etc/resolv.conf`.
- Added `--retry 5 --retry-delay 2 --retry-connrefused` to remote download calls (`curl`).