### PR TITLE
feat(ci): migrate 14 base image build workflows to native GHCR pipelines

### DIFF
--- a/.github/scripts/docker-build-push.sh
+++ b/.github/scripts/docker-build-push.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${IMAGE_NAME:?IMAGE_NAME must be set}"
+: "${DOCKERFILE_PATH:?DOCKERFILE_PATH must be set}"
+
+short_sha="$(git rev-parse --short HEAD)"
+build_context="${BUILD_CONTEXT:-}"
+
+if [[ -z "$build_context" ]]; then
+  if [[ -d "$DOCKERFILE_PATH" ]]; then
+    build_context="$DOCKERFILE_PATH"
+    dockerfile="${DOCKERFILE_PATH}/Dockerfile"
+  else
+    build_context="."
+    dockerfile="$DOCKERFILE_PATH"
+  fi
+else
+  if [[ -d "$DOCKERFILE_PATH" ]]; then
+    dockerfile="${DOCKERFILE_PATH}/Dockerfile"
+  else
+    dockerfile="$DOCKERFILE_PATH"
+  fi
+fi
+
+echo "Building Docker image: ${IMAGE_NAME}:${short_sha} and ${IMAGE_NAME}:latest"
+echo "  Context: ${build_context}"
+echo "  Dockerfile: ${dockerfile}"
+
+docker build \
+  -t "${IMAGE_NAME}:${short_sha}" \
+  -t "${IMAGE_NAME}:latest" \
+  -f "${dockerfile}" \
+  "${build_context}"
+
+if [[ "${PUSH_IMAGE:-true}" == "true" ]]; then
+  echo "Pushing Docker image: ${IMAGE_NAME}:${short_sha} and ${IMAGE_NAME}:latest"
+  docker push "${IMAGE_NAME}:${short_sha}"
+  docker push "${IMAGE_NAME}:latest"
+fi

--- a/.github/workflows/build-ci-image-Ollama.yaml
+++ b/.github/workflows/build-ci-image-Ollama.yaml
@@ -5,23 +5,49 @@ on:
     branches:
       - main
     paths:
-      - 'oci/base/cuda/Ollama/Dockerfile'
+      - 'oci/base/cuda/Ollama/**'
+      - '.github/workflows/build-ci-image-Ollama.yaml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'oci/base/cuda/Ollama/**'
       - '.github/workflows/build-ci-image-Ollama.yaml'
   workflow_dispatch:
+    inputs:
+      runner:
+        description: Runner to execute on
+        required: true
+        default: self-runner
+        type: choice
+        options:
+          - self-runner
+          - ubuntu-latest
+
+permissions:
+  contents: read
+  packages: write
 
 env:
-  IMAGE_REPO: "artifact.svc.plus"
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/cuda-ollama
 
 jobs:
-  build-ollama:
-    name: Build Ollama image
-    uses: svc-design/actions/.github/workflows/build-images.yaml@main
-    with:
-      method: 'docker'
-      registry_addr: "harbor.onwalk.net"
-      dockerfile_path: 'oci/base/cuda/Ollama'
-      image_name: 'public/base/cuda/ollama'
-      image_tag: 'latest'
-    secrets:
-      artifactory_sa: ${{ secrets.REPO_USER }}
-      artifactory_pw: ${{ secrets.HELM_REPO_PASSWORD }}
+  build:
+    name: Build cuda ollama image
+    runs-on: ${{ inputs.runner || 'self-runner' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        env:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          DOCKERFILE_PATH: oci/base/cuda/Ollama
+          PUSH_IMAGE: ${{ github.event_name != 'pull_request' }}
+        run: bash .github/scripts/docker-build-push.sh

--- a/.github/workflows/build-ci-image-SGLang.yaml
+++ b/.github/workflows/build-ci-image-SGLang.yaml
@@ -5,23 +5,49 @@ on:
     branches:
       - main
     paths:
-      - 'oci/base/cuda/SGLang/Dockerfile'
+      - 'oci/base/cuda/SGLang/**'
+      - '.github/workflows/build-ci-image-SGLang.yaml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'oci/base/cuda/SGLang/**'
       - '.github/workflows/build-ci-image-SGLang.yaml'
   workflow_dispatch:
+    inputs:
+      runner:
+        description: Runner to execute on
+        required: true
+        default: self-runner
+        type: choice
+        options:
+          - self-runner
+          - ubuntu-latest
+
+permissions:
+  contents: read
+  packages: write
 
 env:
-  IMAGE_REPO: "artifact.svc.plus"
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/cuda-sglang
 
 jobs:
-  build-sglang:
-    name: Build CUDA SGLang image
-    uses: svc-design/actions/.github/workflows/build-images.yaml@main
-    with:
-      method: 'docker'
-      registry_addr: "harbor.onwalk.net"
-      dockerfile_path: 'oci/base/cuda/SGLang'
-      image_name: 'public/base/cuda/sglang'
-      image_tag: 'cuda12'
-    secrets:
-      artifactory_sa: ${{ secrets.REPO_USER }}
-      artifactory_pw: ${{ secrets.HELM_REPO_PASSWORD }}
+  build:
+    name: Build cuda sglang image
+    runs-on: ${{ inputs.runner || 'self-runner' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        env:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          DOCKERFILE_PATH: oci/base/cuda/SGLang
+          PUSH_IMAGE: ${{ github.event_name != 'pull_request' }}
+        run: bash .github/scripts/docker-build-push.sh

--- a/.github/workflows/build-ci-image-ansible-runer.yml
+++ b/.github/workflows/build-ci-image-ansible-runer.yml
@@ -1,26 +1,53 @@
-name: build images ansible-runner
+name: build image ansible-runner
 
 on:
   pull_request:
     branches:
       - main
     paths:
-      - 'oci/base/alpine-ansible-lint/Dockerfile'
+      - 'oci/base/alpine-ansible-lint/**'
+      - '.github/workflows/build-ci-image-ansible-runer.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'oci/base/alpine-ansible-lint/**'
       - '.github/workflows/build-ci-image-ansible-runer.yml'
   workflow_dispatch:
+    inputs:
+      runner:
+        description: Runner to execute on
+        required: true
+        default: self-runner
+        type: choice
+        options:
+          - self-runner
+          - ubuntu-latest
+
+permissions:
+  contents: read
+  packages: write
+
 env:
-  IMAGE_REPO: "artifact.onwalk.net"
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/alpine-ansible-runner
 
 jobs:
-  eslint:
-    name: Build Docker in Docker image
-    uses: svc-design/actions/.github/workflows/build-images.yaml@main
-    with:
-      method: 'docker/node'
-      registry_addr: "harbor.onwalk.net"
-      dockerfile_path: 'oci/base/alpine-ansible-lint'
-      image_name: 'public/base/alpine-ansible-runer'
-      image_tag: 'latest'
-    secrets:
-      artifactory_sa: ${{ secrets.REPO_USER }}
-      artifactory_pw: ${{ secrets.HELM_REPO_PASSWORD }}
+  build:
+    name: Build ansible runner image
+    runs-on: ${{ inputs.runner || 'self-runner' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        env:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          DOCKERFILE_PATH: oci/base/alpine-ansible-lint
+          PUSH_IMAGE: ${{ github.event_name != 'pull_request' }}
+        run: bash .github/scripts/docker-build-push.sh

--- a/.github/workflows/build-ci-image-docker-dind.yml
+++ b/.github/workflows/build-ci-image-docker-dind.yml
@@ -1,26 +1,53 @@
-name: build images alpine-docker-dind
+name: build image alpine-docker-dind
 
 on:
   pull_request:
     branches:
       - main
     paths:
-      - 'oci/base/alpine-docker-dind/Dockerfile'
+      - 'oci/base/alpine-docker-dind/**'
+      - '.github/workflows/build-ci-image-docker-dind.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'oci/base/alpine-docker-dind/**'
       - '.github/workflows/build-ci-image-docker-dind.yml'
   workflow_dispatch:
+    inputs:
+      runner:
+        description: Runner to execute on
+        required: true
+        default: self-runner
+        type: choice
+        options:
+          - self-runner
+          - ubuntu-latest
+
+permissions:
+  contents: read
+  packages: write
+
 env:
-  IMAGE_REPO: "artifact.onwalk.net"
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/alpine-docker-dind
 
 jobs:
-  eslint:
-    name: Build Docker in Docker image
-    uses: svc-design/actions/.github/workflows/build-images.yaml@main
-    with:
-      method: 'docker/node'
-      registry_addr: "harbor.onwalk.net"
-      dockerfile_path: 'oci/base/alpine-docker-dind'
-      image_name: 'public/base/alpine-docker-dind'
-      image_tag: 'latest'
-    secrets:
-      artifactory_sa: ${{ secrets.REPO_USER }}
-      artifactory_pw: ${{ secrets.HELM_REPO_PASSWORD }}
+  build:
+    name: Build alpine docker dind image
+    runs-on: ${{ inputs.runner || 'self-runner' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        env:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          DOCKERFILE_PATH: oci/base/alpine-docker-dind
+          PUSH_IMAGE: ${{ github.event_name != 'pull_request' }}
+        run: bash .github/scripts/docker-build-push.sh

--- a/.github/workflows/build-ci-image-eslint.yml
+++ b/.github/workflows/build-ci-image-eslint.yml
@@ -1,26 +1,53 @@
-name: build images eslint
+name: build image eslint
 
 on:
   pull_request:
     branches:
       - main
     paths:
-      - 'oci/base/alpine-eslint/Dockerfile'
-      - 'build-ci-image-eslint.yml/build-ci-image-eslint.yml'
+      - 'oci/base/alpine-eslint/**'
+      - '.github/workflows/build-ci-image-eslint.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'oci/base/alpine-eslint/**'
+      - '.github/workflows/build-ci-image-eslint.yml'
   workflow_dispatch:
+    inputs:
+      runner:
+        description: Runner to execute on
+        required: true
+        default: self-runner
+        type: choice
+        options:
+          - self-runner
+          - ubuntu-latest
+
+permissions:
+  contents: read
+  packages: write
+
 env:
-  IMAGE_REPO: "artifact.onwalk.net"
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/alpine-eslint
 
 jobs:
-  eslint:
-    name: Build ESlint image
-    uses: svc-design/actions/.github/workflows/build-images.yaml@main
-    with:
-      method: 'docker/node'
-      registry_addr: "harbor.onwalk.net"
-      dockerfile_path: 'oci/base/alpine-eslint'
-      image_name: 'public/base/alpine-eslint'
-      image_tag: 'latest'
-    secrets:
-      artifactory_sa: ${{ secrets.REPO_USER }}
-      artifactory_pw: ${{ secrets.HELM_REPO_PASSWORD }}
+  build:
+    name: Build alpine eslint image
+    runs-on: ${{ inputs.runner || 'self-runner' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        env:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          DOCKERFILE_PATH: oci/base/alpine-eslint
+          PUSH_IMAGE: ${{ github.event_name != 'pull_request' }}
+        run: bash .github/scripts/docker-build-push.sh

--- a/.github/workflows/build-ci-image-golint.yml
+++ b/.github/workflows/build-ci-image-golint.yml
@@ -1,26 +1,53 @@
-name: build images golint
+name: build image golint
 
 on:
   pull_request:
     branches:
       - main
     paths:
-      - 'oci/base/alpine-golint/Dockerfile'
-      - 'build-ci-image-eslint.yml/build-ci-image-golint.yml'
+      - 'oci/base/alpine-golint/**'
+      - '.github/workflows/build-ci-image-golint.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'oci/base/alpine-golint/**'
+      - '.github/workflows/build-ci-image-golint.yml'
   workflow_dispatch:
+    inputs:
+      runner:
+        description: Runner to execute on
+        required: true
+        default: self-runner
+        type: choice
+        options:
+          - self-runner
+          - ubuntu-latest
+
+permissions:
+  contents: read
+  packages: write
+
 env:
-  IMAGE_REPO: "artifact.onwalk.net"
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/alpine-golint
 
 jobs:
-  eslint:
-    name: Build ESlint image
-    uses: svc-design/actions/.github/workflows/build-images.yaml@main
-    with:
-      method: 'docker/node'
-      registry_addr: "harbor.onwalk.net"
-      dockerfile_path: 'oci/base/alpine-golint'
-      image_name: 'public/base/alpine-golint'
-      image_tag: 'latest'
-    secrets:
-      artifactory_sa: ${{ secrets.REPO_USER }}
-      artifactory_pw: ${{ secrets.HELM_REPO_PASSWORD }}
+  build:
+    name: Build alpine golint image
+    runs-on: ${{ inputs.runner || 'self-runner' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        env:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          DOCKERFILE_PATH: oci/base/alpine-golint
+          PUSH_IMAGE: ${{ github.event_name != 'pull_request' }}
+        run: bash .github/scripts/docker-build-push.sh

--- a/.github/workflows/build-ci-image-proxysql.yml
+++ b/.github/workflows/build-ci-image-proxysql.yml
@@ -5,23 +5,49 @@ on:
     branches:
       - main
     paths:
-      - 'oci/proxysql/Dockerfile'
+      - 'oci/proxysql/**'
+      - '.github/workflows/build-ci-image-proxysql.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'oci/proxysql/**'
       - '.github/workflows/build-ci-image-proxysql.yml'
   workflow_dispatch:
+    inputs:
+      runner:
+        description: Runner to execute on
+        required: true
+        default: self-runner
+        type: choice
+        options:
+          - self-runner
+          - ubuntu-latest
+
+permissions:
+  contents: read
+  packages: write
 
 env:
-  IMAGE_REPO: "artifact.svc.plus"
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/proxysql
 
 jobs:
-  proxysql:
-    name: Build ProxySQL image
-    uses: svc-design/actions/.github/workflows/build-images.yaml@main
-    with:
-      method: 'docker'
-      registry_addr: "ghcr.io"               # 推送到 GitHub Container Registry
-      dockerfile_path: 'oci/proxysql'        # 你放 Dockerfile 的目录
-      image_name: 'public/base/proxysql'     # 镜像仓库路径 (可按你实际改)
-      image_tag: '3.0.2-nojemalloc'          # 标签，可以改成 latest 或 matrix
-    secrets:
-      artifactory_sa: ${{ secrets.REPO_USER }}
-      artifactory_pw: ${{ secrets.HELM_REPO_PASSWORD }}
+  build:
+    name: Build proxysql image
+    runs-on: ${{ inputs.runner || 'self-runner' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        env:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          DOCKERFILE_PATH: oci/proxysql
+          PUSH_IMAGE: ${{ github.event_name != 'pull_request' }}
+        run: bash .github/scripts/docker-build-push.sh

--- a/.github/workflows/build-ci-image-vLLM.yaml
+++ b/.github/workflows/build-ci-image-vLLM.yaml
@@ -5,23 +5,49 @@ on:
     branches:
       - main
     paths:
-      - 'oci/base/cuda/vLLM/Dockerfile'
+      - 'oci/base/cuda/vLLM/**'
+      - '.github/workflows/build-ci-image-vLLM.yaml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'oci/base/cuda/vLLM/**'
       - '.github/workflows/build-ci-image-vLLM.yaml'
   workflow_dispatch:
+    inputs:
+      runner:
+        description: Runner to execute on
+        required: true
+        default: self-runner
+        type: choice
+        options:
+          - self-runner
+          - ubuntu-latest
+
+permissions:
+  contents: read
+  packages: write
 
 env:
-  IMAGE_REPO: "artifact.svc.plus"
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/cuda-vllm
 
 jobs:
-  build-vllm:
-    name: Build CUDA vLLM image
-    uses: svc-design/actions/.github/workflows/build-images.yaml@main
-    with:
-      method: 'docker'
-      registry_addr: "harbor.onwalk.net"
-      dockerfile_path: 'oci/base/cuda/vLLM'
-      image_name: 'public/base/cuda/vllm'
-      image_tag: 'cuda12'
-    secrets:
-      artifactory_sa: ${{ secrets.REPO_USER }}
-      artifactory_pw: ${{ secrets.HELM_REPO_PASSWORD }}
+  build:
+    name: Build cuda vllm image
+    runs-on: ${{ inputs.runner || 'self-runner' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        env:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          DOCKERFILE_PATH: oci/base/cuda/vLLM
+          PUSH_IMAGE: ${{ github.event_name != 'pull_request' }}
+        run: bash .github/scripts/docker-build-push.sh

--- a/.github/workflows/build-go-runtime-base-images.yml
+++ b/.github/workflows/build-go-runtime-base-images.yml
@@ -1,4 +1,4 @@
-name: build images go-runtime
+name: build image go-runtime
 
 on:
   pull_request:
@@ -7,18 +7,47 @@ on:
     paths:
       - 'base-images/go-runtime.Dockerfile'
       - '.github/workflows/build-go-runtime-base-images.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'base-images/go-runtime.Dockerfile'
+      - '.github/workflows/build-go-runtime-base-images.yml'
   workflow_dispatch:
+    inputs:
+      runner:
+        description: Runner to execute on
+        required: true
+        default: self-runner
+        type: choice
+        options:
+          - self-runner
+          - ubuntu-latest
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/base-go-runtime
 
 jobs:
-  build-go-runtime:
-    name: build go runtime image
-    uses: svc-design/actions/.github/workflows/build-images.yaml@main
-    with:
-      method: 'docker/node'
-      registry_addr: images.onwalk.net
-      dockerfile_path: 'base-images/go-runtime.Dockerfile'
-      image_name: 'public/base/go-runtime'
-      image_tag: 'latest'
-    secrets:
-      artifactory_sa: ${{ secrets.IMAGES_REPO_USER }}
-      artifactory_pw: ${{ secrets.IMAGES_REPO_PASSWORD }}
+  build:
+    name: Build go runtime image
+    runs-on: ${{ inputs.runner || 'self-runner' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        env:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          DOCKERFILE_PATH: base-images/go-runtime.Dockerfile
+          PUSH_IMAGE: ${{ github.event_name != 'pull_request' }}
+        run: bash .github/scripts/docker-build-push.sh

--- a/.github/workflows/build-node-builder-base-images.yml
+++ b/.github/workflows/build-node-builder-base-images.yml
@@ -1,4 +1,4 @@
-name: build images node-builder
+name: build image node-builder
 
 on:
   pull_request:
@@ -7,18 +7,47 @@ on:
     paths:
       - 'base-images/node-builder.Dockerfile'
       - '.github/workflows/build-node-builder-base-images.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'base-images/node-builder.Dockerfile'
+      - '.github/workflows/build-node-builder-base-images.yml'
   workflow_dispatch:
+    inputs:
+      runner:
+        description: Runner to execute on
+        required: true
+        default: self-runner
+        type: choice
+        options:
+          - self-runner
+          - ubuntu-latest
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/base-node-builder
 
 jobs:
-  build-node-builder:
-    name: build node builder image
-    uses: svc-design/actions/.github/workflows/build-images.yaml@main
-    with:
-      method: 'docker/node'
-      registry_addr: images.onwalk.net
-      dockerfile_path: 'base-images/node-builder.Dockerfile'
-      image_name: 'public/base/node-builder'
-      image_tag: 'latest'
-    secrets:
-      artifactory_sa: ${{ secrets.IMAGES_REPO_USER }}
-      artifactory_pw: ${{ secrets.IMAGES_REPO_PASSWORD }}
+  build:
+    name: Build node builder image
+    runs-on: ${{ inputs.runner || 'self-runner' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        env:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          DOCKERFILE_PATH: base-images/node-builder.Dockerfile
+          PUSH_IMAGE: ${{ github.event_name != 'pull_request' }}
+        run: bash .github/scripts/docker-build-push.sh

--- a/.github/workflows/build-node-runtime-base-images.yml
+++ b/.github/workflows/build-node-runtime-base-images.yml
@@ -1,4 +1,4 @@
-name: build images node-runtime
+name: build image node-runtime
 
 on:
   pull_request:
@@ -7,18 +7,47 @@ on:
     paths:
       - 'base-images/node-runtime.Dockerfile'
       - '.github/workflows/build-node-runtime-base-images.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'base-images/node-runtime.Dockerfile'
+      - '.github/workflows/build-node-runtime-base-images.yml'
   workflow_dispatch:
+    inputs:
+      runner:
+        description: Runner to execute on
+        required: true
+        default: self-runner
+        type: choice
+        options:
+          - self-runner
+          - ubuntu-latest
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/base-node-runtime
 
 jobs:
-  build-node-runtime:
-    name: build node runtime image
-    uses: svc-design/actions/.github/workflows/build-images.yaml@main
-    with:
-      method: 'docker/node'
-      registry_addr: images.onwalk.net
-      dockerfile_path: 'base-images/node-runtime.Dockerfile'
-      image_name: 'public/base/node-runtime'
-      image_tag: 'latest'
-    secrets:
-      artifactory_sa: ${{ secrets.IMAGES_REPO_USER }}
-      artifactory_pw: ${{ secrets.IMAGES_REPO_PASSWORD }}
+  build:
+    name: Build node runtime image
+    runs-on: ${{ inputs.runner || 'self-runner' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        env:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          DOCKERFILE_PATH: base-images/node-runtime.Dockerfile
+          PUSH_IMAGE: ${{ github.event_name != 'pull_request' }}
+        run: bash .github/scripts/docker-build-push.sh

--- a/.github/workflows/build-openresty-geoip-base-images.yml
+++ b/.github/workflows/build-openresty-geoip-base-images.yml
@@ -1,4 +1,4 @@
-name: build images openresty-geoip
+name: build image openresty-geoip
 
 on:
   pull_request:
@@ -7,18 +7,47 @@ on:
     paths:
       - 'base-images/openresty-geoip.Dockerfile'
       - '.github/workflows/build-openresty-geoip-base-images.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'base-images/openresty-geoip.Dockerfile'
+      - '.github/workflows/build-openresty-geoip-base-images.yml'
   workflow_dispatch:
+    inputs:
+      runner:
+        description: Runner to execute on
+        required: true
+        default: self-runner
+        type: choice
+        options:
+          - self-runner
+          - ubuntu-latest
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/base-openresty-geoip
 
 jobs:
-  build-openresty-geoip:
-    name: build openresty geoip image
-    uses: svc-design/actions/.github/workflows/build-images.yaml@main
-    with:
-      method: 'docker/node'
-      registry_addr: images.onwalk.net
-      dockerfile_path: 'base-images/openresty-geoip.Dockerfile'
-      image_name: 'public/base/openresty-geoip'
-      image_tag: 'latest'
-    secrets:
-      artifactory_sa: ${{ secrets.IMAGES_REPO_USER }}
-      artifactory_pw: ${{ secrets.IMAGES_REPO_PASSWORD }}
+  build:
+    name: Build openresty geoip image
+    runs-on: ${{ inputs.runner || 'self-runner' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        env:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          DOCKERFILE_PATH: base-images/openresty-geoip.Dockerfile
+          PUSH_IMAGE: ${{ github.event_name != 'pull_request' }}
+        run: bash .github/scripts/docker-build-push.sh

--- a/.github/workflows/build-postgresql-backup-images.yml
+++ b/.github/workflows/build-postgresql-backup-images.yml
@@ -1,24 +1,53 @@
-name: build images postgresql-backup
+name: build image postgresql-backup
 
 on:
   pull_request:
     branches:
       - main
     paths:
-      - 'oci/PostgreSQL/backup/Dockerfile'
-      - '.github/workflows/build-python-3.10-base-images.yml'
+      - 'oci/PostgreSQL/backup/**'
+      - '.github/workflows/build-postgresql-backup-images.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'oci/PostgreSQL/backup/**'
+      - '.github/workflows/build-postgresql-backup-images.yml'
   workflow_dispatch:
+    inputs:
+      runner:
+        description: Runner to execute on
+        required: true
+        default: self-runner
+        type: choice
+        options:
+          - self-runner
+          - ubuntu-latest
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/postgresql-backup
 
 jobs:
-  build-postgresql-backup-image:
-    name: build postgresql backup image
-    uses: svc-design/actions/.github/workflows/build-images.yaml@main
-    with:
-      method: 'docker/node'
-      registry_addr: images.onwalk.net
-      dockerfile_path: 'oci/PostgreSQL/backup/'
-      image_name: 'public/postgresql-backup'
-      image_tag: 'latest'
-    secrets:
-      artifactory_sa: ${{ secrets.IMAGES_REPO_USER }}
-      artifactory_pw: ${{ secrets.IMAGES_REPO_PASSWORD }}
+  build:
+    name: Build postgresql backup image
+    runs-on: ${{ inputs.runner || 'self-runner' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        env:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          DOCKERFILE_PATH: oci/PostgreSQL/backup
+          PUSH_IMAGE: ${{ github.event_name != 'pull_request' }}
+        run: bash .github/scripts/docker-build-push.sh

--- a/.github/workflows/build-python-3.10-base-images.yml
+++ b/.github/workflows/build-python-3.10-base-images.yml
@@ -1,24 +1,53 @@
-name: build images python-3.10
+name: build image python-3.10
 
 on:
   pull_request:
     branches:
       - main
     paths:
-      - 'oci/base/python-3.10/Dockerfile'
+      - 'oci/base/python-3.10/**'
+      - '.github/workflows/build-python-3.10-base-images.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'oci/base/python-3.10/**'
       - '.github/workflows/build-python-3.10-base-images.yml'
   workflow_dispatch:
+    inputs:
+      runner:
+        description: Runner to execute on
+        required: true
+        default: self-runner
+        type: choice
+        options:
+          - self-runner
+          - ubuntu-latest
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/base-python-3.10
 
 jobs:
-  build-python-3-10:
-    name: build python 3.10 images
-    uses: svc-design/actions/.github/workflows/build-images.yaml@main
-    with:
-      method: 'docker/node'
-      registry_addr: images.onwalk.net
-      dockerfile_path: 'oci/base/python-3.10'
-      image_name: 'public/base/python-3.10'
-      image_tag: 'latest'
-    secrets:
-      artifactory_sa: ${{ secrets.IMAGES_REPO_USER }}
-      artifactory_pw: ${{ secrets.IMAGES_REPO_PASSWORD }}
+  build:
+    name: Build python 3.10 image
+    runs-on: ${{ inputs.runner || 'self-runner' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        env:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          DOCKERFILE_PATH: oci/base/python-3.10
+          PUSH_IMAGE: ${{ github.event_name != 'pull_request' }}
+        run: bash .github/scripts/docker-build-push.sh


### PR DESCRIPTION
## Outcome
Completely migrated and decoupled 14 container base image build workflows from external `svc-design/actions` reusable workflows to native GHCR Docker pipelines.

## Key Changes
1. **Removed External Dependencies**: Eliminated all `uses: svc-design/actions/.github/workflows/build-images.yaml@main` references.
2. **Standard GHCR Integration**: Configured `docker/login-action@v3` with `GITHUB_TOKEN` to authenticate against GitHub Packages (`ghcr.io`).
3. **Clean Workflow Scripts**: Implemented executable build script `.github/scripts/docker-build-push.sh` to manage image tagging (`SHORT_SHA` and `latest`) and conditional pushing without inline shell script pollution.
4. **Migrated Workflows (14)**:
   - `build-go-runtime-base-images.yml`
   - `build-node-builder-base-images.yml`
   - `build-node-runtime-base-images.yml`
   - `build-openresty-geoip-base-images.yml`
   - `build-python-3.10-base-images.yml`
   - `build-ci-image-ansible-runer.yml`
   - `build-ci-image-docker-dind.yml`
   - `build-ci-image-eslint.yml`
   - `build-ci-image-golint.yml`
   - `build-ci-image-proxysql.yml`
   - `build-ci-image-Ollama.yaml`
   - `build-ci-image-SGLang.yaml`
   - `build-ci-image-vLLM.yaml`
   - `build-postgresql-backup-images.yml`

## Verification Notes
- Validated with custom PyYAML strict duplicate key and syntax checker across all 68 repository workflow files.
- Pushed branch `feature/migrate-base-images-to-ghcr`.