### PR TITLE
fix(packer): lower agent-proxy Golden Image plan to 1C2G

### DIFF
--- a/.github/workflows/packer-vultr-debian13-systemd-agent-proxy.yml
+++ b/.github/workflows/packer-vultr-debian13-systemd-agent-proxy.yml
@@ -20,7 +20,7 @@ on:
       plan_id:
         description: Vultr plan used for the temporary builder VPS
         required: true
-        default: vc2-2c-4gb
+        default: vc2-1c-2gb
         type: string
       os_id:
         description: Optional Vultr OS ID override; blank resolves Debian 13 x64
@@ -46,6 +46,6 @@ jobs:
       source_name: debian13_systemd_agent_proxy
       os_regex: '^Debian 13'
       region_id: ${{ inputs.region_id || 'ewr' }}
-      plan_id: ${{ inputs.plan_id || 'vc2-2c-4gb' }}
+      plan_id: ${{ inputs.plan_id || 'vc2-1c-2gb' }}
       os_id: ${{ inputs.os_id || '' }}
       runner: ${{ inputs.runner || 'ubuntu-latest' }}

--- a/.github/workflows/packer-vultr-ubuntu2604-systemd-agent-proxy.yml
+++ b/.github/workflows/packer-vultr-ubuntu2604-systemd-agent-proxy.yml
@@ -20,7 +20,7 @@ on:
       plan_id:
         description: Vultr plan used for the temporary builder VPS
         required: true
-        default: vc2-2c-4gb
+        default: vc2-1c-2gb
         type: string
       os_id:
         description: Optional Vultr OS ID override; blank resolves Ubuntu 26.04 x64
@@ -46,6 +46,6 @@ jobs:
       source_name: ubuntu2604_systemd_agent_proxy
       os_regex: '^Ubuntu 26\.04'
       region_id: ${{ inputs.region_id || 'ewr' }}
-      plan_id: ${{ inputs.plan_id || 'vc2-2c-4gb' }}
+      plan_id: ${{ inputs.plan_id || 'vc2-1c-2gb' }}
       os_id: ${{ inputs.os_id || '' }}
       runner: ${{ inputs.runner || 'ubuntu-latest' }}

--- a/packer/debian13-systemd-agent-proxy.pkr.hcl
+++ b/packer/debian13-systemd-agent-proxy.pkr.hcl
@@ -39,7 +39,7 @@ variable "vultr_region_id" {
 
 variable "vultr_plan_id" {
   type    = string
-  default = "vc2-2c-4gb"
+  default = "vc2-1c-2gb"
 }
 
 variable "vultr_snapshot_description" {

--- a/packer/ubuntu2604-systemd-agent-proxy.pkr.hcl
+++ b/packer/ubuntu2604-systemd-agent-proxy.pkr.hcl
@@ -39,7 +39,7 @@ variable "vultr_region_id" {
 
 variable "vultr_plan_id" {
   type    = string
-  default = "vc2-2c-4gb"
+  default = "vc2-1c-2gb"
 }
 
 variable "vultr_snapshot_description" {


### PR DESCRIPTION
## Outcome

- Set the default Vultr builder plan for Debian 13 and Ubuntu 26.04 agent-proxy Golden Images to `vc2-1c-2gb`.
- Updated both manual workflow defaults and the HCL template defaults.
- Kept Web SaaS defaults and the shared reusable workflow unchanged.

## Related

- Follow-up correction to [#191](https://github.com/ai-workspace-infra/artifacts/pull/191).
- Issue: N/A.

## Verification

- YAML parsing passed for both agent-proxy workflows and the shared reusable workflow.
- `git diff --check` passed.
- Confirmed all four agent-proxy default values resolve to `vc2-1c-2gb`.
- Packer validation was not run locally because the Packer CLI is not installed in this environment.
