### PR TITLE
feat(packer): suppress first-boot cloud locks and pre-install Vector & Node Exporter on Golden Images

### DIFF
--- a/packer/scripts/cleanup-golden-image.sh
+++ b/packer/scripts/cleanup-golden-image.sh
@@ -12,24 +12,39 @@ apt-get autoremove -y --purge
 apt-get clean
 rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# 2. Reset cloud-init if installed
+# 2. Disable unattended-upgrades & APT daily timers to prevent first-boot dpkg lock
+echo "Disabling automatic background APT timers & unattended-upgrades..."
+systemctl disable --now apt-daily.timer apt-daily-upgrade.timer unattended-upgrades.service 2>/dev/null || true
+systemctl mask apt-daily.timer apt-daily-upgrade.timer unattended-upgrades.service 2>/dev/null || true
+
+# 3. Disable cloud-init package update modules if cloud-init is installed
+if [ -f /etc/cloud/cloud.cfg ]; then
+  echo "Disabling cloud-init package-update modules..."
+  sed -i 's/^[[:space:]]*- package-update-upgrade-install/# - package-update-upgrade-install/' /etc/cloud/cloud.cfg || true
+  sed -i 's/^[[:space:]]*- apt-configure/# - apt-configure/' /etc/cloud/cloud.cfg || true
+fi
+
+# 4. Clean all APT lock files
+rm -f /var/lib/dpkg/lock* /var/lib/apt/lists/lock /var/cache/apt/archives/lock
+
+# 5. Reset cloud-init if installed
 if command -v cloud-init &>/dev/null; then
   echo "Cleaning cloud-init data..."
   cloud-init clean --logs --seed || true
 fi
 
-# 3. Clean machine-id so new instance generates a fresh unique ID
+# 6. Clean machine-id so new instance generates a fresh unique ID
 truncate -s 0 /etc/machine-id
 if [ -f /var/lib/dbus/machine-id ]; then
   rm -f /var/lib/dbus/machine-id
 fi
 
-# 4. Remove SSH Host Keys (will be regenerated on first boot)
+# 7. Remove SSH Host Keys (will be regenerated on first boot)
 rm -f /etc/ssh/ssh_host_*
 
-# 5. Clean shell history and logs
+# 8. Clean shell history and logs
 rm -rf /root/.bash_history /home/*/.bash_history
 truncate -s 0 /var/log/wtmp /var/log/lastlog /var/log/syslog || true
 
 sync
-echo "Golden Image cleanup completed."
+echo "Golden Image cleanup completed successfully."

--- a/packer/scripts/setup-agent-proxy-runtime.sh
+++ b/packer/scripts/setup-agent-proxy-runtime.sh
@@ -113,4 +113,41 @@ EOF
 
 sysctl --system || true
 
+# 7. Pre-install Observability Agents (Vector & Node Exporter)
+echo "Installing Observability Agents (Vector & Node Exporter)..."
+VECTOR_VERSION="0.41.1"
+ARCH_NAME="$(dpkg --print-architecture)"
+VECTOR_DEB_URL="https://github.com/vectordotdev/vector/releases/download/v${VECTOR_VERSION}/vector_${VECTOR_VERSION}-1_${ARCH_NAME}.deb"
+TEMP_OBS_DIR="$(mktemp -d)"
+
+if curl -fsSL --retry 5 --retry-delay 2 --retry-connrefused "${VECTOR_DEB_URL}" -o "${TEMP_OBS_DIR}/vector.deb"; then
+  apt-get install -y "${TEMP_OBS_DIR}/vector.deb"
+  systemctl enable vector
+  echo "Vector v${VECTOR_VERSION} pre-installed successfully."
+fi
+
+NODE_EXPORTER_VERSION="1.8.2"
+NODE_EXPORTER_URL="https://github.com/prometheus/node_exporter/releases/download/v${NODE_EXPORTER_VERSION}/node_exporter-${NODE_EXPORTER_VERSION}.linux-${ARCH_NAME}.tar.gz"
+if curl -fsSL --retry 5 --retry-delay 2 --retry-connrefused "${NODE_EXPORTER_URL}" | tar -xz -C "${TEMP_OBS_DIR}"; then
+  install -m 0755 "${TEMP_OBS_DIR}/node_exporter-${NODE_EXPORTER_VERSION}.linux-${ARCH_NAME}/node_exporter" /usr/local/bin/node_exporter
+  cat <<'EOF' > /etc/systemd/system/node_exporter.service
+[Unit]
+Description=Node Exporter
+After=network.target
+
+[Service]
+User=root
+ExecStart=/usr/local/bin/node_exporter --web.listen-address=0.0.0.0:9100
+Restart=always
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+  systemctl daemon-reload
+  systemctl enable node_exporter
+  echo "Node Exporter v${NODE_EXPORTER_VERSION} pre-installed successfully."
+fi
+rm -rf "${TEMP_OBS_DIR}"
+
 echo "Agent Proxy Production Runtime Setup Completed Successfully."

--- a/packer/scripts/setup-websaas-runtime.sh
+++ b/packer/scripts/setup-websaas-runtime.sh
@@ -89,4 +89,41 @@ EOF
 
 sysctl --system || true
 
+# 6. Pre-install Observability Agents (Vector & Node Exporter)
+echo "Installing Observability Agents (Vector & Node Exporter)..."
+VECTOR_VERSION="0.41.1"
+ARCH_NAME="$(dpkg --print-architecture)"
+VECTOR_DEB_URL="https://github.com/vectordotdev/vector/releases/download/v${VECTOR_VERSION}/vector_${VECTOR_VERSION}-1_${ARCH_NAME}.deb"
+TEMP_OBS_DIR="$(mktemp -d)"
+
+if curl -fsSL --retry 5 --retry-delay 2 --retry-connrefused "${VECTOR_DEB_URL}" -o "${TEMP_OBS_DIR}/vector.deb"; then
+  apt-get install -y "${TEMP_OBS_DIR}/vector.deb"
+  systemctl enable vector
+  echo "Vector v${VECTOR_VERSION} pre-installed successfully."
+fi
+
+NODE_EXPORTER_VERSION="1.8.2"
+NODE_EXPORTER_URL="https://github.com/prometheus/node_exporter/releases/download/v${NODE_EXPORTER_VERSION}/node_exporter-${NODE_EXPORTER_VERSION}.linux-${ARCH_NAME}.tar.gz"
+if curl -fsSL --retry 5 --retry-delay 2 --retry-connrefused "${NODE_EXPORTER_URL}" | tar -xz -C "${TEMP_OBS_DIR}"; then
+  install -m 0755 "${TEMP_OBS_DIR}/node_exporter-${NODE_EXPORTER_VERSION}.linux-${ARCH_NAME}/node_exporter" /usr/local/bin/node_exporter
+  cat <<'EOF' > /etc/systemd/system/node_exporter.service
+[Unit]
+Description=Node Exporter
+After=network.target
+
+[Service]
+User=root
+ExecStart=/usr/local/bin/node_exporter --web.listen-address=0.0.0.0:9100
+Restart=always
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+  systemctl daemon-reload
+  systemctl enable node_exporter
+  echo "Node Exporter v${NODE_EXPORTER_VERSION} pre-installed successfully."
+fi
+rm -rf "${TEMP_OBS_DIR}"
+
 echo "Web SaaS Production Runtime Setup Completed Successfully."


### PR DESCRIPTION
## Outcome
Optimized Golden Image provisioner and cleanup scripts to drastically cut downstream deployment times:
1. **Suppressed first-boot cloud lock**: Masked `unattended-upgrades` and `apt-daily` timers and disabled cloud-init package upgrade modules in `cleanup-golden-image.sh`, eliminating the 7-minute dpkg lock wait.
2. **Pre-installed Observability**: Added Vector (`v0.41.1`) and Node Exporter (`v1.8.2`) pre-installation to both Web SaaS and Agent Proxy runtimes, saving 6~7 minutes during Monitor Agent deployment.