### PR TITLE
perf(packer): preinstall observability runtime in Golden Images

### DIFF
--- a/.github/workflows/packer-vultr-debian13-docker-compose-websaas.yml
+++ b/.github/workflows/packer-vultr-debian13-docker-compose-websaas.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - packer/debian13-docker-compose-websaas.pkr.hcl
       - packer/scripts/setup-websaas-runtime.sh
+      - packer/scripts/setup-observability-runtime.sh
       - packer/scripts/cleanup-golden-image.sh
       - .github/scripts/**
       - .github/workflows/packer-vultr-debian13-docker-compose-websaas.yml

--- a/.github/workflows/packer-vultr-debian13-systemd-agent-proxy.yml
+++ b/.github/workflows/packer-vultr-debian13-systemd-agent-proxy.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - packer/debian13-systemd-agent-proxy.pkr.hcl
       - packer/scripts/setup-agent-proxy-runtime.sh
+      - packer/scripts/setup-observability-runtime.sh
       - packer/scripts/cleanup-golden-image.sh
       - .github/scripts/**
       - .github/workflows/packer-vultr-debian13-systemd-agent-proxy.yml

--- a/.github/workflows/packer-vultr-ubuntu2604-docker-compose-websaas.yml
+++ b/.github/workflows/packer-vultr-ubuntu2604-docker-compose-websaas.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - packer/ubuntu2604-docker-compose-websaas.pkr.hcl
       - packer/scripts/setup-websaas-runtime.sh
+      - packer/scripts/setup-observability-runtime.sh
       - packer/scripts/cleanup-golden-image.sh
       - .github/scripts/**
       - .github/workflows/packer-vultr-ubuntu2604-docker-compose-websaas.yml

--- a/.github/workflows/packer-vultr-ubuntu2604-systemd-agent-proxy.yml
+++ b/.github/workflows/packer-vultr-ubuntu2604-systemd-agent-proxy.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - packer/ubuntu2604-systemd-agent-proxy.pkr.hcl
       - packer/scripts/setup-agent-proxy-runtime.sh
+      - packer/scripts/setup-observability-runtime.sh
       - packer/scripts/cleanup-golden-image.sh
       - .github/scripts/**
       - .github/workflows/packer-vultr-ubuntu2604-systemd-agent-proxy.yml

--- a/packer/README.md
+++ b/packer/README.md
@@ -13,6 +13,11 @@
 
 手动运行时可选择 Vultr region、临时构建 VPS plan，并可用 `os_id` 覆盖动态 OS ID 解析。合并到 `main` 后，模板变更会自动走 UAT 发布。
 
+四套镜像都会预装观测运行时二进制：Vector、Node Exporter 和 Process Exporter；Web SaaS
+镜像额外预装 PostgreSQL Exporter。镜像只提供不可变二进制与 systemd unit，不写入任何
+运行时凭据，也不会在构建阶段启动依赖业务配置的 exporter。Agent Proxy 镜像明确不安装
+Docker，Docker 仅属于 Web SaaS 镜像。
+
 ## Vault prerequisites
 
 工作流使用 GitHub OIDC 登录 Vault，不从 GitHub Actions Secrets 读取 Vultr API key。UAT 需要在下面的 Vault 路径提供 `VULTR_API_KEY`：

--- a/packer/debian13-docker-compose-websaas.pkr.hcl
+++ b/packer/debian13-docker-compose-websaas.pkr.hcl
@@ -91,6 +91,11 @@ build {
   }
 
   provisioner "shell" {
+    script = "scripts/setup-observability-runtime.sh"
+    environment_vars = ["INSTALL_POSTGRES_EXPORTER=1"]
+  }
+
+  provisioner "shell" {
     script = "scripts/cleanup-golden-image.sh"
   }
 }
@@ -112,6 +117,11 @@ build {
 
   provisioner "shell" {
     script = "scripts/setup-websaas-runtime.sh"
+  }
+
+  provisioner "shell" {
+    script = "scripts/setup-observability-runtime.sh"
+    environment_vars = ["INSTALL_POSTGRES_EXPORTER=1"]
   }
 
   provisioner "shell" {

--- a/packer/debian13-systemd-agent-proxy.pkr.hcl
+++ b/packer/debian13-systemd-agent-proxy.pkr.hcl
@@ -91,6 +91,10 @@ build {
   }
 
   provisioner "shell" {
+    script = "scripts/setup-observability-runtime.sh"
+  }
+
+  provisioner "shell" {
     script = "scripts/cleanup-golden-image.sh"
   }
 }
@@ -112,6 +116,10 @@ build {
 
   provisioner "shell" {
     script = "scripts/setup-agent-proxy-runtime.sh"
+  }
+
+  provisioner "shell" {
+    script = "scripts/setup-observability-runtime.sh"
   }
 
   provisioner "shell" {

--- a/packer/scripts/setup-agent-proxy-runtime.sh
+++ b/packer/scripts/setup-agent-proxy-runtime.sh
@@ -113,41 +113,4 @@ EOF
 
 sysctl --system || true
 
-# 7. Pre-install Observability Agents (Vector & Node Exporter)
-echo "Installing Observability Agents (Vector & Node Exporter)..."
-VECTOR_VERSION="0.41.1"
-ARCH_NAME="$(dpkg --print-architecture)"
-VECTOR_DEB_URL="https://github.com/vectordotdev/vector/releases/download/v${VECTOR_VERSION}/vector_${VECTOR_VERSION}-1_${ARCH_NAME}.deb"
-TEMP_OBS_DIR="$(mktemp -d)"
-
-if curl -fsSL --retry 5 --retry-delay 2 --retry-connrefused "${VECTOR_DEB_URL}" -o "${TEMP_OBS_DIR}/vector.deb"; then
-  apt-get install -y "${TEMP_OBS_DIR}/vector.deb"
-  systemctl enable vector
-  echo "Vector v${VECTOR_VERSION} pre-installed successfully."
-fi
-
-NODE_EXPORTER_VERSION="1.8.2"
-NODE_EXPORTER_URL="https://github.com/prometheus/node_exporter/releases/download/v${NODE_EXPORTER_VERSION}/node_exporter-${NODE_EXPORTER_VERSION}.linux-${ARCH_NAME}.tar.gz"
-if curl -fsSL --retry 5 --retry-delay 2 --retry-connrefused "${NODE_EXPORTER_URL}" | tar -xz -C "${TEMP_OBS_DIR}"; then
-  install -m 0755 "${TEMP_OBS_DIR}/node_exporter-${NODE_EXPORTER_VERSION}.linux-${ARCH_NAME}/node_exporter" /usr/local/bin/node_exporter
-  cat <<'EOF' > /etc/systemd/system/node_exporter.service
-[Unit]
-Description=Node Exporter
-After=network.target
-
-[Service]
-User=root
-ExecStart=/usr/local/bin/node_exporter --web.listen-address=0.0.0.0:9100
-Restart=always
-RestartSec=5s
-
-[Install]
-WantedBy=multi-user.target
-EOF
-  systemctl daemon-reload
-  systemctl enable node_exporter
-  echo "Node Exporter v${NODE_EXPORTER_VERSION} pre-installed successfully."
-fi
-rm -rf "${TEMP_OBS_DIR}"
-
 echo "Agent Proxy Production Runtime Setup Completed Successfully."

--- a/packer/scripts/setup-observability-runtime.sh
+++ b/packer/scripts/setup-observability-runtime.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Pre-install the binaries used by playbooks/deploy_observability_agent.yml.
+# Configuration, credentials, and service activation remain deployment-time
+# concerns; the Golden Image only carries immutable runtime artifacts.
+
+export DEBIAN_FRONTEND=noninteractive
+
+ARCH_NAME="$(dpkg --print-architecture)"
+case "${ARCH_NAME}" in
+  amd64|arm64) ;;
+  *)
+    echo "Unsupported Debian architecture: ${ARCH_NAME}" >&2
+    exit 1
+    ;;
+esac
+
+METRICS_DIR=/opt/metrics-agent
+mkdir -p "${METRICS_DIR}"
+
+VECTOR_VERSION="0.41.1"
+NODE_EXPORTER_VERSION="1.8.2"
+PROCESS_EXPORTER_VERSION="0.7.10"
+POSTGRES_EXPORTER_VERSION="0.19.1"
+
+TEMP_OBS_DIR="$(mktemp -d)"
+trap 'rm -rf "${TEMP_OBS_DIR}"' EXIT
+
+echo "Pre-installing observability runtime for ${ARCH_NAME}..."
+
+# Vector is installed from the same package used by the Vector Ansible role.
+VECTOR_DEB_URL="https://github.com/vectordotdev/vector/releases/download/v${VECTOR_VERSION}/vector_${VECTOR_VERSION}-1_${ARCH_NAME}.deb"
+if ! command -v vector >/dev/null 2>&1; then
+  curl -fsSL --retry 5 --retry-delay 2 --retry-connrefused \
+    "${VECTOR_DEB_URL}" -o "${TEMP_OBS_DIR}/vector.deb"
+  apt-get install -y "${TEMP_OBS_DIR}/vector.deb"
+fi
+
+install -m 0755 -d /etc/vector
+systemctl enable vector || true
+
+# Match roles/vhosts/node_exporter exactly so a later convergence only needs
+# to render configuration and restart the service instead of downloading it.
+NODE_EXPORTER_URL="https://github.com/prometheus/node_exporter/releases/download/v${NODE_EXPORTER_VERSION}/node_exporter-${NODE_EXPORTER_VERSION}.linux-${ARCH_NAME}.tar.gz"
+if [[ ! -x "${METRICS_DIR}/node_exporter" ]]; then
+  curl -fsSL --retry 5 --retry-delay 2 --retry-connrefused \
+    "${NODE_EXPORTER_URL}" | tar -xz -C "${TEMP_OBS_DIR}"
+  install -m 0755 \
+    "${TEMP_OBS_DIR}/node_exporter-${NODE_EXPORTER_VERSION}.linux-${ARCH_NAME}/node_exporter" \
+    "${METRICS_DIR}/node_exporter"
+fi
+
+install -d -o nobody -g nogroup -m 0755 /var/lib/node_exporter
+cat > /etc/systemd/system/node-exporter.service <<'EOF'
+[Unit]
+Description=Node Exporter
+After=network.target
+
+[Service]
+User=nobody
+Group=nogroup
+ExecStart=/opt/metrics-agent/node_exporter --web.listen-address=127.0.0.1:9100 --collector.textfile --collector.textfile.directory=/var/lib/node_exporter
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Process exporter is intentionally installed but not started: its config is
+# deployment-specific and is rendered by the Ansible role.
+if [[ ! -x /usr/local/bin/process-exporter ]]; then
+  PROCESS_EXPORTER_URL="https://github.com/ncabatoff/process-exporter/releases/download/v${PROCESS_EXPORTER_VERSION}/process-exporter-${PROCESS_EXPORTER_VERSION}.linux-${ARCH_NAME}.tar.gz"
+  curl -fsSL --retry 5 --retry-delay 2 --retry-connrefused \
+    "${PROCESS_EXPORTER_URL}" | tar -xz -C "${TEMP_OBS_DIR}"
+  install -m 0755 \
+    "${TEMP_OBS_DIR}/process-exporter-${PROCESS_EXPORTER_VERSION}.linux-${ARCH_NAME}/process-exporter" \
+    /usr/local/bin/process-exporter
+fi
+
+if ! getent group process_exporter >/dev/null 2>&1; then
+  groupadd --system process_exporter
+fi
+if ! id process_exporter >/dev/null 2>&1; then
+  useradd --system --gid process_exporter --shell /usr/sbin/nologin --no-create-home process_exporter
+fi
+cat > /etc/systemd/system/process-exporter.service <<'EOF'
+[Unit]
+Description=process-exporter
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=process_exporter
+Group=process_exporter
+ExecStart=/usr/local/bin/process-exporter --config.path /etc/process-exporter.yml --web.listen-address=127.0.0.1:9256
+Restart=always
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=full
+ProtectHome=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+install -m 0755 -o process_exporter -g process_exporter /dev/null /etc/process-exporter.yml
+
+# PostgreSQL exporter is only needed on the Web SaaS image. It is never
+# started here because its connection credentials are environment-specific.
+if [[ "${INSTALL_POSTGRES_EXPORTER:-0}" == "1" ]]; then
+  case "${ARCH_NAME}" in
+    amd64) POSTGRES_EXPORTER_SHA256="229096c7988df6ca41fe5b4bf66865089971535e7f0d819c12c920ec64dd2bd0" ;;
+    arm64) POSTGRES_EXPORTER_SHA256="0ac6fe8c1f66f13b12adb8da282d248d9e1a48df6684e453ca232fd8fd62a11a" ;;
+  esac
+  POSTGRES_EXPORTER_URL="https://github.com/prometheus-community/postgres_exporter/releases/download/v${POSTGRES_EXPORTER_VERSION}/postgres_exporter-${POSTGRES_EXPORTER_VERSION}.linux-${ARCH_NAME}.tar.gz"
+  POSTGRES_EXPORTER_ARCHIVE="${TEMP_OBS_DIR}/postgres_exporter.tar.gz"
+  curl -fsSL --retry 5 --retry-delay 2 --retry-connrefused \
+    "${POSTGRES_EXPORTER_URL}" -o "${POSTGRES_EXPORTER_ARCHIVE}"
+  printf '%s  %s\n' "${POSTGRES_EXPORTER_SHA256}" "${POSTGRES_EXPORTER_ARCHIVE}" | sha256sum -c -
+  tar -xzf "${POSTGRES_EXPORTER_ARCHIVE}" -C "${TEMP_OBS_DIR}"
+  install -m 0755 \
+    "${TEMP_OBS_DIR}/postgres_exporter-${POSTGRES_EXPORTER_VERSION}.linux-${ARCH_NAME}/postgres_exporter" \
+    "${METRICS_DIR}/postgres_exporter"
+fi
+
+systemctl daemon-reload || true
+systemctl enable node-exporter || true
+echo "Observability runtime pre-install completed successfully."

--- a/packer/scripts/setup-websaas-runtime.sh
+++ b/packer/scripts/setup-websaas-runtime.sh
@@ -89,41 +89,4 @@ EOF
 
 sysctl --system || true
 
-# 6. Pre-install Observability Agents (Vector & Node Exporter)
-echo "Installing Observability Agents (Vector & Node Exporter)..."
-VECTOR_VERSION="0.41.1"
-ARCH_NAME="$(dpkg --print-architecture)"
-VECTOR_DEB_URL="https://github.com/vectordotdev/vector/releases/download/v${VECTOR_VERSION}/vector_${VECTOR_VERSION}-1_${ARCH_NAME}.deb"
-TEMP_OBS_DIR="$(mktemp -d)"
-
-if curl -fsSL --retry 5 --retry-delay 2 --retry-connrefused "${VECTOR_DEB_URL}" -o "${TEMP_OBS_DIR}/vector.deb"; then
-  apt-get install -y "${TEMP_OBS_DIR}/vector.deb"
-  systemctl enable vector
-  echo "Vector v${VECTOR_VERSION} pre-installed successfully."
-fi
-
-NODE_EXPORTER_VERSION="1.8.2"
-NODE_EXPORTER_URL="https://github.com/prometheus/node_exporter/releases/download/v${NODE_EXPORTER_VERSION}/node_exporter-${NODE_EXPORTER_VERSION}.linux-${ARCH_NAME}.tar.gz"
-if curl -fsSL --retry 5 --retry-delay 2 --retry-connrefused "${NODE_EXPORTER_URL}" | tar -xz -C "${TEMP_OBS_DIR}"; then
-  install -m 0755 "${TEMP_OBS_DIR}/node_exporter-${NODE_EXPORTER_VERSION}.linux-${ARCH_NAME}/node_exporter" /usr/local/bin/node_exporter
-  cat <<'EOF' > /etc/systemd/system/node_exporter.service
-[Unit]
-Description=Node Exporter
-After=network.target
-
-[Service]
-User=root
-ExecStart=/usr/local/bin/node_exporter --web.listen-address=0.0.0.0:9100
-Restart=always
-RestartSec=5s
-
-[Install]
-WantedBy=multi-user.target
-EOF
-  systemctl daemon-reload
-  systemctl enable node_exporter
-  echo "Node Exporter v${NODE_EXPORTER_VERSION} pre-installed successfully."
-fi
-rm -rf "${TEMP_OBS_DIR}"
-
 echo "Web SaaS Production Runtime Setup Completed Successfully."

--- a/packer/ubuntu2604-docker-compose-websaas.pkr.hcl
+++ b/packer/ubuntu2604-docker-compose-websaas.pkr.hcl
@@ -78,6 +78,11 @@ build {
   }
 
   provisioner "shell" {
+    script = "scripts/setup-observability-runtime.sh"
+    environment_vars = ["INSTALL_POSTGRES_EXPORTER=1"]
+  }
+
+  provisioner "shell" {
     script = "scripts/cleanup-golden-image.sh"
   }
 }
@@ -99,6 +104,11 @@ build {
 
   provisioner "shell" {
     script = "scripts/setup-websaas-runtime.sh"
+  }
+
+  provisioner "shell" {
+    script = "scripts/setup-observability-runtime.sh"
+    environment_vars = ["INSTALL_POSTGRES_EXPORTER=1"]
   }
 
   provisioner "shell" {

--- a/packer/ubuntu2604-systemd-agent-proxy.pkr.hcl
+++ b/packer/ubuntu2604-systemd-agent-proxy.pkr.hcl
@@ -78,6 +78,10 @@ build {
   }
 
   provisioner "shell" {
+    script = "scripts/setup-observability-runtime.sh"
+  }
+
+  provisioner "shell" {
     script = "scripts/cleanup-golden-image.sh"
   }
 }
@@ -99,6 +103,10 @@ build {
 
   provisioner "shell" {
     script = "scripts/setup-agent-proxy-runtime.sh"
+  }
+
+  provisioner "shell" {
+    script = "scripts/setup-observability-runtime.sh"
   }
 
   provisioner "shell" {


### PR DESCRIPTION
## Outcome

- Add a shared observability-runtime Packer provisioner to all four production Golden Image templates.
- Preinstall Vector, Node Exporter, and Process Exporter using the paths and service names expected by the Ansible observability roles.
- Preinstall PostgreSQL Exporter only on Web SaaS images; it is not enabled because credentials are deployment-specific.
- Keep Agent Proxy images Docker-free; Docker remains only in the existing Web SaaS runtime setup.
- Add the new helper to all four Vultr workflow path triggers.

## Related

- Builds on the existing Golden Image releases and observability preinstall work in [#193](https://github.com/ai-workspace-infra/artifacts/pull/193) and [#194](https://github.com/ai-workspace-infra/artifacts/pull/194).

## Verification

- Bash syntax checks passed for all runtime scripts.
- YAML parsing passed for all Vultr Packer workflows.
- Static checks confirmed all four templates wire the observability provisioner and only Web SaaS enables PostgreSQL Exporter.
- Confirmed Agent Proxy runtime scripts contain no Docker packages.
- Packer CLI is not installed locally, so `packer fmt`/`packer validate` remain to be run by CI.

## Follow-up

- These changes require rebuilding the four Vultr Snapshots after merge; the currently published Snapshot IDs do not contain this new layer yet.
- PostgreSQL readiness and Web SaaS observe polling remain in the platform-ops/playbooks repositories.
