### PR TITLE
feat: add distributed self-hosted web saas chart

### DIFF
--- a/oci/charts/distributed-web-saas-fullstack/Chart.yaml
+++ b/oci/charts/distributed-web-saas-fullstack/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: distributed-web-saas-fullstack
+description: Open, self-hostable distributed Web SaaS full-stack for K3s and Kubernetes
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+keywords:
+  - distributed
+  - self-hosted
+  - k3s
+  - kubernetes
+  - web-saas
+home: https://github.com/ai-workspace-infra/artifacts
+maintainers:
+  - name: AI Workspace Infrastructure

--- a/oci/charts/distributed-web-saas-fullstack/README.md
+++ b/oci/charts/distributed-web-saas-fullstack/README.md
@@ -1,0 +1,39 @@
+# Distributed Web SaaS Fullstack Chart
+
+This is a standalone umbrella Chart for an open/self-hosted, distributed Web
+SaaS installation on K3s or Kubernetes. It deliberately does not depend on the
+legacy `web-saas` chart, whose subcharts are an earlier scaffold.
+
+## Components
+
+```text
+Ingress (Traefik or Caddy)
+  -> frontend-router
+     -> static-assets, SSR auth/content/console/workspace/public
+     -> edge-gateway-router
+        -> edge-gateway-auth, edge-gateway-admin, edge-gateway-core
+           -> accounts, content, billing, PostgreSQL
+```
+
+`edge-gateway-router` is an internal Caddy path router. Cloudflare provides
+this behaviour through Worker Route precedence; Kubernetes requires it to be
+declared explicitly. `edge-gateway-core` remains the stable fallback Worker
+role and is displayed as **Edge Gateway Router Core**.
+
+## K3s open profile
+
+1. Build and publish every application image with the same immutable tag.
+2. Create the PostgreSQL Secret and the runtime Secret (or configure Vault CSI
+   / External Secrets). Do not put either value in Helm values.
+3. Replace `daily-build-REPLACE_ME` in `values-open.yaml` with the selected
+   immutable tag and set image repositories if your registry differs.
+4. Install with `helm upgrade --install ... -f values-open.yaml`.
+
+The default profile is intentionally single replica, ClusterIP-only, Traefik
+Ingress, and one PostgreSQL StatefulSet with a K3s `local-path` PVC. Its
+database image is `ghcr.io/ai-workspace-infra/postgresql:17`, built and
+published by `ai-workspace-services/postgresql.svc.plus`; do not replace it
+with the generic upstream PostgreSQL image. HA, HPA, external/self-hosted
+Supabase, Vault injection, and NetworkPolicy are later production profiles;
+migrations remain controlled by the delivery `operation`, not Helm lifecycle
+hooks.

--- a/oci/charts/distributed-web-saas-fullstack/templates/NOTES.txt
+++ b/oci/charts/distributed-web-saas-fullstack/templates/NOTES.txt
@@ -1,0 +1,9 @@
+Install the open K3s profile with:
+
+  helm upgrade --install <release> . \
+    --namespace web-saas --create-namespace \
+    -f values-open.yaml
+
+Before the install, create the PostgreSQL password Secret and configure the
+runtime Secret/Vault integration. Replace every `daily-build-REPLACE_ME` image
+tag with an immutable image tag produced by the relevant service repository.

--- a/oci/charts/distributed-web-saas-fullstack/templates/_helpers.tpl
+++ b/oci/charts/distributed-web-saas-fullstack/templates/_helpers.tpl
@@ -1,0 +1,19 @@
+{{- define "distributed-web-saas-fullstack.name" -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "distributed-web-saas-fullstack.fullname" -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "distributed-web-saas-fullstack.componentName" -}}
+{{- printf "%s-%s" (include "distributed-web-saas-fullstack.fullname" .root) .name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "distributed-web-saas-fullstack.labels" -}}
+app.kubernetes.io/name: {{ include "distributed-web-saas-fullstack.name" .root }}
+app.kubernetes.io/instance: {{ .root.Release.Name }}
+app.kubernetes.io/component: {{ .name }}
+app.kubernetes.io/managed-by: {{ .root.Release.Service }}
+helm.sh/chart: {{ .root.Chart.Name }}-{{ .root.Chart.Version | replace "+" "_" }}
+{{- end -}}

--- a/oci/charts/distributed-web-saas-fullstack/templates/components.yaml
+++ b/oci/charts/distributed-web-saas-fullstack/templates/components.yaml
@@ -1,0 +1,99 @@
+{{- $root := . -}}
+{{- range $name, $component := .Values.components }}
+{{- if $component.enabled }}
+{{- $context := dict "root" $root "name" $name }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "distributed-web-saas-fullstack.componentName" $context }}
+  labels:
+    {{- include "distributed-web-saas-fullstack.labels" $context | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ $root.Release.Name }}
+      app.kubernetes.io/component: {{ $name }}
+  template:
+    metadata:
+      labels:
+        {{- include "distributed-web-saas-fullstack.labels" $context | nindent 8 }}
+        {{- with $root.Values.global.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with $root.Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ $name }}
+          image: {{ required (printf "components.%s.image is required" $name) $component.image | quote }}
+          imagePullPolicy: IfNotPresent
+          {{- with $component.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ default 8080 $component.port }}
+          {{- with $component.env }}
+          env:
+            {{- range $key := keys . | sortAlpha }}
+            - name: {{ $key }}
+              value: {{ index $component.env $key | replace "RELEASE_NAME" $root.Release.Name | quote }}
+            {{- end }}
+          {{- end }}
+          {{- with $component.secretRefs }}
+          envFrom:
+            {{- range . }}
+            - secretRef:
+                name: {{ . }}
+            {{- end }}
+          {{- end }}
+          readinessProbe:
+            httpGet:
+              path: {{ default "/healthz" $component.healthPath }}
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: {{ default "/healthz" $component.healthPath }}
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            {{- toYaml (default (dict "requests" (dict "cpu" "50m" "memory" "128Mi") "limits" (dict "cpu" "500m" "memory" "512Mi")) $component.resources) | nindent 12 }}
+          {{- if $component.configMap }}
+          volumeMounts:
+            - name: configuration
+              mountPath: /etc/caddy/Caddyfile
+              subPath: Caddyfile
+              readOnly: true
+          {{- end }}
+      {{- if $component.configMap }}
+      volumes:
+        - name: configuration
+          configMap:
+            name: {{ include "distributed-web-saas-fullstack.componentName" (dict "root" $root "name" $component.configMap) }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "distributed-web-saas-fullstack.componentName" $context }}
+  labels:
+    {{- include "distributed-web-saas-fullstack.labels" $context | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/instance: {{ $root.Release.Name }}
+    app.kubernetes.io/component: {{ $name }}
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+{{- end }}
+{{- end }}

--- a/oci/charts/distributed-web-saas-fullstack/templates/edge-gateway-router.yaml
+++ b/oci/charts/distributed-web-saas-fullstack/templates/edge-gateway-router.yaml
@@ -1,0 +1,29 @@
+{{- $root := . -}}
+{{- $router := index .Values.components "edge-gateway-router" -}}
+{{- if and $router $router.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "distributed-web-saas-fullstack.componentName" (dict "root" . "name" "edge-gateway-router") }}
+  labels:
+    {{- include "distributed-web-saas-fullstack.labels" (dict "root" . "name" "edge-gateway-router") | nindent 4 }}
+data:
+  Caddyfile: |
+    :8080 {
+      respond /healthz 200
+
+      @auth path /api/auth/* /api/v1/auth/*
+      handle @auth {
+        reverse_proxy {{ include "distributed-web-saas-fullstack.componentName" (dict "root" $root "name" "edge-gateway-auth") }}:80
+      }
+
+      @admin path /api/admin/*
+      handle @admin {
+        reverse_proxy {{ include "distributed-web-saas-fullstack.componentName" (dict "root" $root "name" "edge-gateway-admin") }}:80
+      }
+
+      handle {
+        reverse_proxy {{ include "distributed-web-saas-fullstack.componentName" (dict "root" $root "name" "edge-gateway-core") }}:80
+      }
+    }
+{{- end }}

--- a/oci/charts/distributed-web-saas-fullstack/templates/ingress.yaml
+++ b/oci/charts/distributed-web-saas-fullstack/templates/ingress.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "distributed-web-saas-fullstack.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "distributed-web-saas-fullstack.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - host: {{ required "ingress.consoleHost is required" .Values.ingress.consoleHost }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "distributed-web-saas-fullstack.componentName" (dict "root" . "name" "frontend-router") }}
+                port:
+                  number: 80
+    - host: {{ required "ingress.accountsHost is required" .Values.ingress.accountsHost }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "distributed-web-saas-fullstack.componentName" (dict "root" . "name" "edge-gateway-router") }}
+                port:
+                  number: 80
+{{- end }}

--- a/oci/charts/distributed-web-saas-fullstack/templates/postgresql.yaml
+++ b/oci/charts/distributed-web-saas-fullstack/templates/postgresql.yaml
@@ -1,0 +1,78 @@
+{{- if eq .Values.database.mode "postgresql" }}
+{{- $database := .Values.database.postgresql }}
+{{- if not $database.enabled }}{{ fail "database.postgresql.enabled must be true when database.mode=postgresql" }}{{ end }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "distributed-web-saas-fullstack.fullname" . }}-postgresql
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: postgresql
+  ports:
+    - name: postgresql
+      port: 5432
+      targetPort: postgresql
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "distributed-web-saas-fullstack.fullname" . }}-postgresql
+  labels:
+    app.kubernetes.io/name: {{ include "distributed-web-saas-fullstack.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: postgresql
+spec:
+  serviceName: {{ include "distributed-web-saas-fullstack.fullname" . }}-postgresql
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: postgresql
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "distributed-web-saas-fullstack.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: postgresql
+    spec:
+      containers:
+        - name: postgresql
+          image: {{ required "database.postgresql.image is required" $database.image | quote }}
+          ports:
+            - name: postgresql
+              containerPort: 5432
+          env:
+            - name: POSTGRES_USER
+              value: {{ $database.username | quote }}
+            - name: POSTGRES_DB
+              value: {{ $database.database | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "database.postgresql.existingSecret is required" $database.existingSecret }}
+                  key: {{ default "password" $database.secretKey }}
+          readinessProbe:
+            exec:
+              command: [sh, -c, "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
+          livenessProbe:
+            exec:
+              command: [sh, -c, "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
+          resources:
+            {{- toYaml (default (dict "requests" (dict "cpu" "250m" "memory" "512Mi") "limits" (dict "cpu" "1" "memory" "1Gi")) $database.resources) | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: [ReadWriteOnce]
+        {{- with $database.storageClass }}
+        storageClassName: {{ . }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ $database.size }}
+{{- end }}

--- a/oci/charts/distributed-web-saas-fullstack/values-open.yaml
+++ b/oci/charts/distributed-web-saas-fullstack/values-open.yaml
@@ -1,0 +1,162 @@
+# K3s / single-node open self-hosted profile.
+#
+# Before install, create the PostgreSQL password Secret and replace every
+# application image with an immutable daily-build-* or v* image tag:
+#   kubectl -n web-saas create secret generic distributed-web-saas-postgresql \
+#     --from-literal=password='<generated-password>'
+#
+# Application secrets (JWT, service tokens and DB URI) are not stored here.
+# Mount them through the named Kubernetes Secret, Vault CSI, or External
+# Secrets controller used by the target cluster.
+global:
+  imagePullSecrets: []
+  podLabels:
+    app.kubernetes.io/part-of: distributed-web-saas-fullstack
+
+ingress:
+  enabled: true
+  # K3s ships Traefik by default. Set this to `caddy` only when a Caddy
+  # ingress controller is installed in the cluster.
+  className: traefik
+  consoleHost: console.localhost
+  accountsHost: accounts.localhost
+  annotations: {}
+  tls: []
+
+database:
+  mode: postgresql
+  postgresql:
+    enabled: true
+    # Built and published by ai-workspace-services/postgresql.svc.plus.
+    image: ghcr.io/ai-workspace-infra/postgresql:17
+    existingSecret: distributed-web-saas-postgresql
+    secretKey: password
+    username: app
+    database: app
+    storageClass: local-path
+    size: 10Gi
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        cpu: "1"
+        memory: 1Gi
+
+components:
+  frontend-router:
+    enabled: true
+    image: ghcr.io/ai-workspace-services/frontend-router:daily-build-REPLACE_ME
+    port: 8080
+    healthPath: /healthz
+    env:
+      STATIC_ORIGIN: http://RELEASE_NAME-static-assets
+      SSR_AUTH_ORIGIN: http://RELEASE_NAME-ssr-auth
+      SSR_CONTENT_ORIGIN: http://RELEASE_NAME-ssr-content
+      SSR_CONSOLE_ORIGIN: http://RELEASE_NAME-ssr-console
+      SSR_WORKSPACE_ORIGIN: http://RELEASE_NAME-ssr-workspace
+      SSR_PUBLIC_ORIGIN: http://RELEASE_NAME-ssr-public
+      API_ORIGIN: http://RELEASE_NAME-edge-gateway-router
+    secretRefs:
+      - distributed-web-saas-runtime
+
+  static-assets:
+    enabled: true
+    image: ghcr.io/ai-workspace-services/portal:daily-build-REPLACE_ME
+    port: 8080
+    healthPath: /healthz
+
+  ssr-auth:
+    enabled: true
+    image: ghcr.io/ai-workspace-services/portal-ssr-auth:daily-build-REPLACE_ME
+    port: 8080
+    healthPath: /healthz
+  ssr-content:
+    enabled: true
+    image: ghcr.io/ai-workspace-services/portal-ssr-content:daily-build-REPLACE_ME
+    port: 8080
+    healthPath: /healthz
+  ssr-console:
+    enabled: true
+    image: ghcr.io/ai-workspace-services/portal-ssr-console:daily-build-REPLACE_ME
+    port: 8080
+    healthPath: /healthz
+  ssr-workspace:
+    enabled: true
+    image: ghcr.io/ai-workspace-services/portal-ssr-workspace:daily-build-REPLACE_ME
+    port: 8080
+    healthPath: /healthz
+  ssr-public:
+    enabled: true
+    image: ghcr.io/ai-workspace-services/portal-ssr-public:daily-build-REPLACE_ME
+    port: 8080
+    healthPath: /healthz
+
+  # Cloudflare performs this path matching through Worker Routes. K3s needs
+  # an explicit internal router; this Caddy instance keeps the three Gateway
+  # shards private ClusterIP services.
+  edge-gateway-router:
+    enabled: true
+    image: caddy:2.8.4-alpine
+    port: 8080
+    healthPath: /healthz
+    configMap: edge-gateway-router
+
+  edge-gateway-auth:
+    enabled: true
+    image: ghcr.io/ai-workspace-services/edge-gateway:daily-build-REPLACE_ME
+    command: [node, dist/workers/auth.js]
+    port: 8080
+    healthPath: /healthz
+    env:
+      RUNTIME_MODE: selfhost
+      PRIMARY_UPSTREAM: http://RELEASE_NAME-accounts
+    secretRefs:
+      - distributed-web-saas-runtime
+  edge-gateway-admin:
+    enabled: true
+    image: ghcr.io/ai-workspace-services/edge-gateway:daily-build-REPLACE_ME
+    command: [node, dist/workers/admin.js]
+    port: 8080
+    healthPath: /healthz
+    env:
+      RUNTIME_MODE: selfhost
+      PRIMARY_UPSTREAM: http://RELEASE_NAME-accounts
+    secretRefs:
+      - distributed-web-saas-runtime
+  edge-gateway-core:
+    enabled: true
+    displayName: Edge Gateway Router Core
+    image: ghcr.io/ai-workspace-services/edge-gateway:daily-build-REPLACE_ME
+    command: [node, dist/workers/core.js]
+    port: 8080
+    healthPath: /healthz
+    env:
+      RUNTIME_MODE: selfhost
+      PRIMARY_UPSTREAM: http://RELEASE_NAME-accounts
+      CONTENT_UPSTREAM: http://RELEASE_NAME-content
+      BILLING_UPSTREAM: http://RELEASE_NAME-billing
+    secretRefs:
+      - distributed-web-saas-runtime
+
+  accounts:
+    enabled: true
+    image: ghcr.io/ai-workspace-services/accounts:daily-build-REPLACE_ME
+    port: 8080
+    healthPath: /healthz
+    secretRefs:
+      - distributed-web-saas-runtime
+  content:
+    enabled: true
+    image: ghcr.io/ai-workspace-services/content-service:daily-build-REPLACE_ME
+    port: 8080
+    healthPath: /healthz
+    secretRefs:
+      - distributed-web-saas-runtime
+  billing:
+    enabled: true
+    image: ghcr.io/ai-workspace-services/billing-service:daily-build-REPLACE_ME
+    port: 8080
+    healthPath: /healthz
+    secretRefs:
+      - distributed-web-saas-runtime

--- a/oci/charts/distributed-web-saas-fullstack/values.yaml
+++ b/oci/charts/distributed-web-saas-fullstack/values.yaml
@@ -1,0 +1,28 @@
+# Base values intentionally do not name a public image tag. Install the
+# open/self-hosted profile with `-f values-open.yaml` and replace each image
+# with an immutable tag produced by the corresponding service repository.
+global:
+  imagePullSecrets: []
+  podLabels: {}
+
+ingress:
+  enabled: false
+  className: traefik
+  consoleHost: console.localhost
+  accountsHost: accounts.localhost
+  annotations: {}
+  tls: []
+
+database:
+  mode: postgresql
+  postgresql:
+    enabled: true
+    image: ghcr.io/ai-workspace-infra/postgresql:17
+    existingSecret: distributed-web-saas-postgresql
+    secretKey: password
+    username: app
+    database: app
+    storageClass: ""
+    size: 10Gi
+
+components: {}


### PR DESCRIPTION
## Outcome

Adds an independent Helm umbrella Chart for deploying the distributed Web SaaS topology to a single-node K3s installation, without changing the legacy `web-saas` Chart.

## Issue

- N/A — implementation requested directly for the new open/self-hosted K3s chart profile.

## Scope

- Added `oci/charts/distributed-web-saas-fullstack` with K3s open values, Ingress, internal Caddy API router, application Deployments/Services, and a PostgreSQL StatefulSet/PVC.
- Models Frontend Router, static assets, five SSR services, Gateway auth/admin/core, Accounts, Content, and Billing as independent ClusterIP workloads.
- Uses `ghcr.io/ai-workspace-infra/postgresql:17`, published by `ai-workspace-services/postgresql.svc.plus`.
- Did not modify the legacy `web-saas` chart, create application images, add a Node adapter for the Frontend Router, or deploy a live cluster.

## Verification

- `ruby -ryaml ... Chart.yaml values.yaml values-open.yaml` — passed.
- `docker ... alpine/helm:3.16.1 helm lint /chart -f /chart/values-open.yaml` — passed.
- `docker ... alpine/helm:3.16.1 helm template distributed-web-saas /chart -f /chart/values-open.yaml` — rendered 32 Kubernetes documents.
- Ruby YAML parsing of rendered manifests — passed.
- Live K3s install — not run; immutable application images and cluster Secrets must be supplied by the deployment environment.

## Risk / Security / Configuration

- No credentials or database URI are stored in the Chart. PostgreSQL and runtime Secret names are references only.
- `values-open.yaml` uses placeholder immutable image tags that must be replaced with real build tags before deployment.
- The profile is single replica and uses K3s `local-path`; it is not an HA production profile.

## Rollback

- Revert this PR before publishing the Chart, or uninstall the dedicated Helm release from the target namespace.
- The existing `web-saas` chart and all live environments are unchanged.

## Related

- Companion architecture: https://github.com/ai-workspace-services/knowledge/pull/37
- Frontend Router implementation: https://github.com/ai-workspace-services/frontend-router/pull/1
- Gateway routing contract: https://github.com/ai-workspace-services/edge-gateway/pull/11
- GitOps contract: https://github.com/ai-workspace-infra/gitops/pull/162
